### PR TITLE
add tests for exception classes

### DIFF
--- a/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleAssignmentException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleAssignmentException.java
@@ -1,0 +1,70 @@
+package org.whdl.frontend.syntaxtree;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+public class TestMultipleAssignmentException {
+
+  private NamespaceIdentifier namespaceIdentifierInstance;
+
+  private NamespaceIdentifier getNamespaceIdentifierInstance() {
+    if (namespaceIdentifierInstance == null) {
+      ArrayList<String> name = new ArrayList<String>(1);
+      name.add("whdl");
+
+      namespaceIdentifierInstance = new NamespaceIdentifier(name);
+    }
+
+    return namespaceIdentifierInstance;
+  }
+
+  private VariableIdentifier getVariableIdentifierInstance() {
+    return new VariableIdentifier(getNamespaceIdentifierInstance(), "foo");
+  }
+  
+  // because we just need something that returns a type, without bringing too
+  // much else into the works
+  // FIXME(lucas) Remove this once we have an actual LiteralExpression
+  static private class FacadeExpression extends Expression {
+    
+    private Value value;
+ 
+    public FacadeExpression(Value value) {
+      this.value = value;
+    }
+
+    @Override
+    public Value evaluate() { return value; }
+
+    @Override
+    public TypeValue getType() { return value.getType(); }
+ 
+  }
+
+  private Expression getTypeExpression(){
+    return new FacadeExpression(BitTypeValue.getInstance());
+  }
+  
+  private Variable v_inst = null; 
+  public Variable getVariableInstance(){
+    if(v_inst == null){
+      v_inst = new Variable(getVariableIdentifierInstance(), getTypeExpression());
+    }
+    return v_inst;
+  }
+  
+  public MultipleAssignmentException getInstance(){
+    return new MultipleAssignmentException(getVariableInstance());
+  }
+  
+  @Test
+  public void testGetMessage_containsVariableIdentifier() {
+    MultipleAssignmentException instance = getInstance();
+    String message = instance.getMessage();
+    assertTrue(message.contains(getVariableInstance().getIdentifier().toString()));
+  }
+
+}

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleAssignmentException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleAssignmentException.java
@@ -8,17 +8,10 @@ import org.junit.Test;
 
 public class TestMultipleAssignmentException {
 
-  private NamespaceIdentifier namespaceIdentifierInstance;
-
   private NamespaceIdentifier getNamespaceIdentifierInstance() {
-    if (namespaceIdentifierInstance == null) {
-      ArrayList<String> name = new ArrayList<String>(1);
-      name.add("whdl");
-
-      namespaceIdentifierInstance = new NamespaceIdentifier(name);
-    }
-
-    return namespaceIdentifierInstance;
+    ArrayList<String> name = new ArrayList<String>(1);
+    name.add("whdl");
+    return new NamespaceIdentifier(name);
   }
 
   private VariableIdentifier getVariableIdentifierInstance() {
@@ -29,12 +22,8 @@ public class TestMultipleAssignmentException {
     return new LiteralExpression(BitTypeValue.getInstance());
   }
   
-  private Variable v_inst = null; 
   public Variable getVariableInstance(){
-    if(v_inst == null){
-      v_inst = new Variable(getVariableIdentifierInstance(), getTypeExpression());
-    }
-    return v_inst;
+      return new Variable(getVariableIdentifierInstance(), getTypeExpression());
   }
   
   public MultipleAssignmentException getInstance(){

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleAssignmentException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleAssignmentException.java
@@ -24,28 +24,9 @@ public class TestMultipleAssignmentException {
   private VariableIdentifier getVariableIdentifierInstance() {
     return new VariableIdentifier(getNamespaceIdentifierInstance(), "foo");
   }
-  
-  // because we just need something that returns a type, without bringing too
-  // much else into the works
-  // FIXME(lucas) Remove this once we have an actual LiteralExpression
-  static private class FacadeExpression extends Expression {
-    
-    private Value value;
- 
-    public FacadeExpression(Value value) {
-      this.value = value;
-    }
-
-    @Override
-    public Value evaluate() { return value; }
-
-    @Override
-    public TypeValue getType() { return value.getType(); }
- 
-  }
 
   private Expression getTypeExpression(){
-    return new FacadeExpression(BitTypeValue.getInstance());
+    return new LiteralExpression(BitTypeValue.getInstance());
   }
   
   private Variable v_inst = null; 

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleDefinitionException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleDefinitionException.java
@@ -1,0 +1,39 @@
+package org.whdl.frontend.syntaxtree;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+public class TestMultipleDefinitionException {
+
+  private NamespaceIdentifier namespaceIdentifierInstance;
+
+  private NamespaceIdentifier getNamespaceIdentifierInstance() {
+    if (namespaceIdentifierInstance == null) {
+      ArrayList<String> name = new ArrayList<String>(1);
+      name.add("whdl");
+
+      namespaceIdentifierInstance = new NamespaceIdentifier(name);
+    }
+
+    return namespaceIdentifierInstance;
+  }
+
+  private VariableIdentifier getVariableIdentifierInstance() {
+    return new VariableIdentifier(getNamespaceIdentifierInstance(), "foo");
+  }
+  
+  public MultipleDefinitionException getInstance(){
+    return new MultipleDefinitionException(getVariableIdentifierInstance());
+  }
+  
+  @Test
+  public void testGetMessage_containsVariableIdentifier() {
+    MultipleDefinitionException instance = getInstance();
+    String message = instance.getMessage();
+    assertTrue(message.contains(getVariableIdentifierInstance().toString()));
+  }
+
+}

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleDefinitionException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestMultipleDefinitionException.java
@@ -8,17 +8,10 @@ import org.junit.Test;
 
 public class TestMultipleDefinitionException {
 
-  private NamespaceIdentifier namespaceIdentifierInstance;
-
   private NamespaceIdentifier getNamespaceIdentifierInstance() {
-    if (namespaceIdentifierInstance == null) {
-      ArrayList<String> name = new ArrayList<String>(1);
-      name.add("whdl");
-
-      namespaceIdentifierInstance = new NamespaceIdentifier(name);
-    }
-
-    return namespaceIdentifierInstance;
+    ArrayList<String> name = new ArrayList<String>(1);
+    name.add("whdl");
+    return new NamespaceIdentifier(name);
   }
 
   private VariableIdentifier getVariableIdentifierInstance() {

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestTypeMismatchException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestTypeMismatchException.java
@@ -1,0 +1,29 @@
+package org.whdl.frontend.syntaxtree;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestTypeMismatchException {
+
+  public TypeValue getTypeValueInstance(){
+    return BitTypeValue.getInstance();
+  }
+  
+  public Value getValueInstance(){
+    return BitValue.getInstance(false);
+  }
+  
+  public TypeMismatchException getInstance(){
+    return new TypeMismatchException(getTypeValueInstance(), getValueInstance());
+  }
+  
+  @Test
+  public void testGetMessage_containsTypeNames() {
+    TypeMismatchException instance = getInstance();
+    String msg = instance.getMessage();
+    assertTrue(msg.contains(getTypeValueInstance().toString()));
+    assertTrue(msg.contains(getValueInstance().toString()));
+  }
+
+}

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotAssignedException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotAssignedException.java
@@ -24,28 +24,9 @@ public class TestVariableNotAssignedException {
   private VariableIdentifier getVariableIdentifierInstance() {
     return new VariableIdentifier(getNamespaceIdentifierInstance(), "foo");
   }
-  
-  // because we just need something that returns a type, without bringing too
-  // much else into the works
-  // FIXME(lucas) Remove this once we have an actual LiteralExpression
-  static private class FacadeExpression extends Expression {
-    
-    private Value value;
- 
-    public FacadeExpression(Value value) {
-      this.value = value;
-    }
-
-    @Override
-    public Value evaluate() { return value; }
-
-    @Override
-    public TypeValue getType() { return value.getType(); }
- 
-  }
 
   private Expression getTypeExpression(){
-    return new FacadeExpression(BitTypeValue.getInstance());
+    return new LiteralExpression(BitTypeValue.getInstance());
   }
   
   private Variable v_inst = null; 

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotAssignedException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotAssignedException.java
@@ -8,17 +8,10 @@ import org.junit.Test;
 
 public class TestVariableNotAssignedException {
 
-  private NamespaceIdentifier namespaceIdentifierInstance;
-
   private NamespaceIdentifier getNamespaceIdentifierInstance() {
-    if (namespaceIdentifierInstance == null) {
-      ArrayList<String> name = new ArrayList<String>(1);
-      name.add("whdl");
-
-      namespaceIdentifierInstance = new NamespaceIdentifier(name);
-    }
-
-    return namespaceIdentifierInstance;
+    ArrayList<String> name = new ArrayList<String>(1);
+    name.add("whdl");
+    return new NamespaceIdentifier(name);
   }
 
   private VariableIdentifier getVariableIdentifierInstance() {
@@ -29,12 +22,8 @@ public class TestVariableNotAssignedException {
     return new LiteralExpression(BitTypeValue.getInstance());
   }
   
-  private Variable v_inst = null; 
   public Variable getVariableInstance(){
-    if(v_inst == null){
-      v_inst = new Variable(getVariableIdentifierInstance(), getTypeExpression());
-    }
-    return v_inst;
+    return new Variable(getVariableIdentifierInstance(), getTypeExpression());
   }
   
   public VariableNotAssignedException getInstance(){

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotAssignedException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotAssignedException.java
@@ -1,0 +1,70 @@
+package org.whdl.frontend.syntaxtree;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+public class TestVariableNotAssignedException {
+
+  private NamespaceIdentifier namespaceIdentifierInstance;
+
+  private NamespaceIdentifier getNamespaceIdentifierInstance() {
+    if (namespaceIdentifierInstance == null) {
+      ArrayList<String> name = new ArrayList<String>(1);
+      name.add("whdl");
+
+      namespaceIdentifierInstance = new NamespaceIdentifier(name);
+    }
+
+    return namespaceIdentifierInstance;
+  }
+
+  private VariableIdentifier getVariableIdentifierInstance() {
+    return new VariableIdentifier(getNamespaceIdentifierInstance(), "foo");
+  }
+  
+  // because we just need something that returns a type, without bringing too
+  // much else into the works
+  // FIXME(lucas) Remove this once we have an actual LiteralExpression
+  static private class FacadeExpression extends Expression {
+    
+    private Value value;
+ 
+    public FacadeExpression(Value value) {
+      this.value = value;
+    }
+
+    @Override
+    public Value evaluate() { return value; }
+
+    @Override
+    public TypeValue getType() { return value.getType(); }
+ 
+  }
+
+  private Expression getTypeExpression(){
+    return new FacadeExpression(BitTypeValue.getInstance());
+  }
+  
+  private Variable v_inst = null; 
+  public Variable getVariableInstance(){
+    if(v_inst == null){
+      v_inst = new Variable(getVariableIdentifierInstance(), getTypeExpression());
+    }
+    return v_inst;
+  }
+  
+  public VariableNotAssignedException getInstance(){
+    return new VariableNotAssignedException(getVariableInstance());
+  }
+  
+  @Test
+  public void testGetMessage_containsVariableIdentifier() {
+    VariableNotAssignedException instance = getInstance();
+    String message = instance.getMessage();
+    assertTrue(message.contains(getVariableInstance().getIdentifier().toString()));
+  }
+
+}

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotDefinedException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotDefinedException.java
@@ -8,17 +8,10 @@ import org.junit.Test;
 
 public class TestVariableNotDefinedException {
 
-  private NamespaceIdentifier namespaceIdentifierInstance;
-
   private NamespaceIdentifier getNamespaceIdentifierInstance() {
-    if (namespaceIdentifierInstance == null) {
-      ArrayList<String> name = new ArrayList<String>(1);
-      name.add("whdl");
-
-      namespaceIdentifierInstance = new NamespaceIdentifier(name);
-    }
-
-    return namespaceIdentifierInstance;
+    ArrayList<String> name = new ArrayList<String>(1);
+    name.add("whdl");
+    return new NamespaceIdentifier(name);
   }
 
   private VariableIdentifier getVariableIdentifierInstance() {

--- a/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotDefinedException.java
+++ b/src/test/java/org/whdl/frontend/syntaxtree/TestVariableNotDefinedException.java
@@ -1,0 +1,39 @@
+package org.whdl.frontend.syntaxtree;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+public class TestVariableNotDefinedException {
+
+  private NamespaceIdentifier namespaceIdentifierInstance;
+
+  private NamespaceIdentifier getNamespaceIdentifierInstance() {
+    if (namespaceIdentifierInstance == null) {
+      ArrayList<String> name = new ArrayList<String>(1);
+      name.add("whdl");
+
+      namespaceIdentifierInstance = new NamespaceIdentifier(name);
+    }
+
+    return namespaceIdentifierInstance;
+  }
+
+  private VariableIdentifier getVariableIdentifierInstance() {
+    return new VariableIdentifier(getNamespaceIdentifierInstance(), "foo");
+  }
+  
+  public VariableNotDefinedException getInstance(){
+    return new VariableNotDefinedException(getVariableIdentifierInstance());
+  }
+  
+  @Test
+  public void testGetMessage_containsVariableIdentifier() {
+    VariableNotDefinedException instance = getInstance();
+    String message = instance.getMessage();
+    assertTrue(message.contains(getVariableIdentifierInstance().toString()));
+  }
+
+}


### PR DESCRIPTION
addresses issue #52

Something is very fishy with the code coverage report, as it says that for all the exception classes I'm testing, I'm not calling the getMessage() method, even though the tests very clearly do this...
