### PR TITLE
Implemented basic serialization for intermediate schematics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
 repositories {
   mavenCentral()
 }
 
 dependencies {
+  compile 'com.google.code.gson:gson:2.2.4'
+  compile 'com.google.guava:guava:17.0'
   testCompile 'junit:junit:4.11'
 }
 

--- a/src/main/java/org/whdl/intermediate/Schematic.java
+++ b/src/main/java/org/whdl/intermediate/Schematic.java
@@ -1,12 +1,17 @@
 package org.whdl.intermediate;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 /**
- * A Schematic contains all the information needed by the intermediate representation.
- * This includes type definitions, node/connection definitions, node/connection instantiations,
- * and constraint definitions/instantiations.
+ * A Schematic contains all the information needed by the intermediate
+ * representation. This includes type definitions, node/connection definitions,
+ * node/connection instantiations, and constraint definitions/instantiations.
  */
 public class Schematic {
   private String name;
@@ -22,8 +27,8 @@ public class Schematic {
   private Map<String, Node> nodes;
   private Map<String, Connection> connections;
   private Map<String, Constraint> constraints;
-  
-  public Schematic(String name){
+
+  public Schematic(String name) {
     this.name = name;
     
     this.userDefinedTypes = new HashMap<String, Type>();
@@ -38,11 +43,11 @@ public class Schematic {
     this.connections = new HashMap<String, Connection>();
     this.constraints = new HashMap<String, Constraint>();
   }
-  
+
   /*
-   * Add "library standard" type definitions for basic types
-   * such as integer, string, and boolean.
-   * Every class in .intermediate.types should be represented in here.
+   * Add "library standard" type definitions for basic types such as integer,
+   * string, and boolean. Every class in .intermediate.types should be
+   * represented in here.
    */
   private void populateDefaultTypeDefinitions(){
     Type boolType = BooleanType.getInstance();
@@ -106,6 +111,7 @@ public class Schematic {
   public void addConnectionTypeDefinition(String typename, ConnectionType cd) throws MultipleDefinitionException{
     if(connectionTypes.containsKey(typename)){
       throw new MultipleDefinitionException("connection-definition", typename);
+
     }
     connectionTypes.put(typename, cd);
   }
@@ -132,7 +138,23 @@ public class Schematic {
       throw new UndeclaredIdentifierException(typename);
     }
   }
-  
-  // FIXME do we add nodes as a function of their node definition right away, or just record that the node "will" exist with such-and-such definition and elaborate it later?
-  
+
+  // FIXME do we add nodes as a function of their node definition right away, or
+  // just record that the node "will" exist with such-and-such definition and
+  // elaborate it later?
+
+  public void serialize(BufferedWriter out, boolean pretty) throws IOException {
+    Gson gson;
+    if (pretty) {
+      gson = new GsonBuilder().setPrettyPrinting().create();
+    } else {
+      gson = new Gson();
+    }
+    out.write(gson.toJson(this));
+    out.flush();
+  }
+
+  public void serialize(BufferedWriter out) throws IOException {
+    serialize(out, false);
+  }
 }

--- a/src/test/java/org/whdl/intermediate/TestSerialization.java
+++ b/src/test/java/org/whdl/intermediate/TestSerialization.java
@@ -1,0 +1,37 @@
+package org.whdl.intermediate;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSerialization {
+
+  private Schematic testSchematic;
+
+  @Before
+  public void setup() throws MultipleDefinitionException {
+
+    testSchematic = new Schematic("test");
+    Type t1 = IntegerType.getInstance();
+    testSchematic.addUserDefinedTypeDefinition("type1", t1);
+
+    ConstraintType c1 = new ConstraintType(new HashMap<String, Type>());
+    testSchematic.addConstraintTypeDefinition("constraint1", c1);
+    NodeType n1 = new NodeType(new HashMap<String, Type>(), new HashMap<String, PortType>());
+    testSchematic.addNodeTypeDefinition("node1", n1);
+
+    HashMap<String, Type> attributes = new HashMap<String, Type>();
+    attributes.put("imakey", t1);
+    PortType e1 = new PortType(attributes);
+    testSchematic.addPortTypeDefinition("n1", e1);
+  }
+
+  @Test
+  public void testAddConstraintDef() throws IOException {
+    testSchematic.serialize(new BufferedWriter(new OutputStreamWriter(System.out)), true);
+  }
+}

--- a/src/test/java/org/whdl/intermediate/TestSerialization.java
+++ b/src/test/java/org/whdl/intermediate/TestSerialization.java
@@ -1,8 +1,10 @@
 package org.whdl.intermediate;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.StringWriter;
 import java.util.HashMap;
 
 import org.junit.Before;
@@ -10,28 +12,46 @@ import org.junit.Test;
 
 public class TestSerialization {
 
+  private static final String TEST_SCHEMATIC_NAME = "dogematics";
+  private static final String TEST_TYPE_NAME = "very type";
+  private static final String TEST_CONSTRAINT_TYPE_NAME = "much constraint";
+  private static final String TEST_NODE_TYPE_NAME = "such node";
+  private static final String TEST_PORT_TYPE_NAME = "wow port";
+  private static final String TEST_PORT_TYPE_ATTRIBUTE_NAME = "much attributes";
+
   private Schematic testSchematic;
 
   @Before
   public void setup() throws MultipleDefinitionException {
 
-    testSchematic = new Schematic("test");
+    testSchematic = new Schematic(TEST_SCHEMATIC_NAME);
     Type t1 = IntegerType.getInstance();
-    testSchematic.addUserDefinedTypeDefinition("type1", t1);
+    testSchematic.addUserDefinedTypeDefinition(TEST_TYPE_NAME, t1);
 
     ConstraintType c1 = new ConstraintType(new HashMap<String, Type>());
-    testSchematic.addConstraintTypeDefinition("constraint1", c1);
+    testSchematic.addConstraintTypeDefinition(TEST_CONSTRAINT_TYPE_NAME, c1);
     NodeType n1 = new NodeType(new HashMap<String, Type>(), new HashMap<String, PortType>());
-    testSchematic.addNodeTypeDefinition("node1", n1);
+    testSchematic.addNodeTypeDefinition(TEST_NODE_TYPE_NAME, n1);
 
     HashMap<String, Type> attributes = new HashMap<String, Type>();
-    attributes.put("imakey", t1);
+    attributes.put(TEST_PORT_TYPE_ATTRIBUTE_NAME, t1);
     PortType e1 = new PortType(attributes);
-    testSchematic.addPortTypeDefinition("n1", e1);
+    testSchematic.addPortTypeDefinition(TEST_PORT_TYPE_NAME, e1);
   }
 
   @Test
   public void testAddConstraintDef() throws IOException {
-    testSchematic.serialize(new BufferedWriter(new OutputStreamWriter(System.out)), true);
+    StringWriter outbuffer = new StringWriter();
+    testSchematic.serialize(new BufferedWriter(outbuffer));
+    String result = outbuffer.toString();
+
+    assertTrue(result.contains(TEST_SCHEMATIC_NAME));
+    assertTrue(result.contains(TEST_TYPE_NAME));
+    assertTrue(result.contains(TEST_CONSTRAINT_TYPE_NAME));
+    assertTrue(result.contains(TEST_NODE_TYPE_NAME));
+    assertTrue(result.contains(TEST_PORT_TYPE_NAME));
+    assertTrue(result.contains(TEST_PORT_TYPE_ATTRIBUTE_NAME));
+
+    System.out.println(result);
   }
 }


### PR DESCRIPTION
In my search through available JSON libraries, I came across Gson, which seems a lot nicer than writing everything ourselves. Everything's pretty basic and the "test" isn't much of a test yet, just something to see what it outputs. From what I can see there isn't anything to do with adding actual values to the schematic yet, just type definitions?

Also, I'm kind of lost on the whole TypeTypeDefinition / PrimitiveType / PrimitiveKind stuff. I recall seeing another pull request where they were removed... was that not merged in yet?

Aside: I think my formatter went a little crazy on some of the lines. Let me know if you guys care about those (although some of them were really long)

Here's the output from running that 1 basic test:

Fixes #86

```
{
  "name": "test",
  "userDefinedTypes": {
    "Bool": {},
    "type1": {},
    "String": {},
    "Int": {}
  },
  "portTypes": {
    "n1": {
      "attributes": {
        "imakey": {}
      }
    }
  },
  "nodeTypes": {
    "node1": {
      "attributes": {},
      "ports": {}
    }
  },
  "connectionTypes": {},
  "constraintTypes": {
    "constraint1": {
      "arguments": {}
    }
  },
  "nodes": {},
  "connections": {},
  "constraints": {}
}
```
