### PR TITLE
Digital backend: basic netlist construction and digital primitives

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -9,6 +9,10 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
 <module name="Checker">
 
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressions.xml" />
+  </module>
+
   <module name="FileTabCharacter">
     <!-- Checks that there are no tab characters in the file. -->
   </module>
@@ -282,5 +286,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
     </module>
 
   </module>
+
 </module>
 

--- a/src/main/java/org/manifold/backend/digital/InputPinPrimitive.java
+++ b/src/main/java/org/manifold/backend/digital/InputPinPrimitive.java
@@ -1,0 +1,15 @@
+package org.manifold.backend.digital;
+
+import org.manifold.backend.digital.Port.PortDirection;
+import org.manifold.intermediate.Node;
+
+public class InputPinPrimitive extends Primitive {
+  
+  private Port out = new Port("out", PortDirection.OUTPUT);
+
+  public InputPinPrimitive(String name, Node node){
+    super(name);
+    addPort(out);
+  }
+  
+}

--- a/src/main/java/org/manifold/backend/digital/Net.java
+++ b/src/main/java/org/manifold/backend/digital/Net.java
@@ -20,12 +20,8 @@ public class Net {
     return java.util.Collections.unmodifiableSet(ports);
   }
   
-  public void addPort(Port p){
+  public void addPort(Port p) throws NetlistConstructionException{
     ports.add(p);
     p.setNet(this);
-  }
-  
-  public void removePort(Port p){
-    ports.remove(p);
   }
 }

--- a/src/main/java/org/manifold/backend/digital/Net.java
+++ b/src/main/java/org/manifold/backend/digital/Net.java
@@ -1,0 +1,31 @@
+package org.manifold.backend.digital;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Net {
+  
+  private String name;
+  public String getName(){
+    return name;
+  }
+  
+  public Net(String name){
+    this.name = name;
+  }
+  
+  private Set<Port> ports = new HashSet<Port>();
+  
+  public Set<Port> getPorts(){
+    return java.util.Collections.unmodifiableSet(ports);
+  }
+  
+  public void addPort(Port p){
+    ports.add(p);
+    p.setNet(this);
+  }
+  
+  public void removePort(Port p){
+    ports.remove(p);
+  }
+}

--- a/src/main/java/org/manifold/backend/digital/Netlist.java
+++ b/src/main/java/org/manifold/backend/digital/Netlist.java
@@ -1,0 +1,171 @@
+package org.manifold.backend.digital;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import org.manifold.intermediate.Connection;
+import org.manifold.intermediate.ConnectionType;
+import org.manifold.intermediate.Node;
+import org.manifold.intermediate.PortType;
+import org.manifold.intermediate.Schematic;
+import org.manifold.intermediate.NodeType;
+import org.manifold.intermediate.UndeclaredIdentifierException;
+
+/**
+ * Representation of a digital circuit as a collection of
+ * Primitives (equivalent to IR Nodes) and Nets (built from IR Connections).
+ */
+public class Netlist {
+  
+  @FunctionalInterface
+  interface BiFunctionConstructor<T, U, R> {
+    R apply(T t, U u) throws SchematicConstructionException;
+  }
+  
+  /**
+   * Associates intermediate node types with functions that can be used to construct named primitives of that kind of node.
+   */
+  private Map<NodeType, BiFunctionConstructor<String, Node,Primitive> > primitiveConstructor = new HashMap<NodeType, BiFunctionConstructor<String, Node,Primitive> >();
+  
+  private Map<Node, Primitive> translatedPrimitives = new HashMap<Node, Primitive>();
+  public Set<Primitive> getPrimitives(){
+    return java.util.Collections.unmodifiableSet(new HashSet<Primitive>(translatedPrimitives.values()));
+  }
+  
+  private Set<Net> nets = new HashSet<Net>();
+  public Set<Net> getNets(){
+    return java.util.Collections.unmodifiableSet(nets);
+  }
+  
+  private ConnectionType wireConnectionType;
+  
+  private PortType inPortType;
+  private PortType outPortType;
+  
+  public Netlist(Schematic schematic) throws SchematicConstructionException{
+    // start by examining the Schematic's definitions for certain node types we are interested in seeing
+    try{
+      primitiveConstructor.put(schematic.getNodeType("register"), (name, node) -> {
+        return new RegisterPrimitive(name, node);
+      });
+      primitiveConstructor.put(schematic.getNodeType("inputPin"), (name, node) -> {
+        return new InputPinPrimitive(name, node);
+      });
+      primitiveConstructor.put(schematic.getNodeType("outputPin"), (name, node) -> {
+        return new OutputPinPrimitive(name, node);
+      });
+    }catch(UndeclaredIdentifierException uie){
+      // FIXME subclass this and make a more specific exception
+      throw new SchematicConstructionException(uie.getMessage() + " while searching for node types");
+    }
+    
+    // now look for connection types
+    try{
+      wireConnectionType = schematic.getConnectionType("digitalWire");
+    }catch(UndeclaredIdentifierException uie){
+      // FIXME subclass this
+      throw new SchematicConstructionException(uie.getMessage() + " while searching for connection types");
+    }
+    
+    // now look for port types
+    try{
+      inPortType = schematic.getPortType("digitalIn");
+      outPortType = schematic.getPortType("digitalOut");
+    }catch(UndeclaredIdentifierException uie){
+      // FIXME subclass this
+      throw new SchematicConstructionException(uie.getMessage() + " while searching for port types");
+    }
+    
+    // now, assuming that went well, we can build a lookup table from Node -> Primitive
+    for(Map.Entry<String, Node> e : schematic.getNodes().entrySet()){
+      String nodeName = e.getKey();
+      Node node = e.getValue();
+      NodeType nodeType = (NodeType)node.getType();
+      Primitive prim = primitiveConstructor.get(nodeType).apply(nodeName, node);
+      translatedPrimitives.put(node, prim);
+    }
+    
+    // Every digitalWire in the schematic is a statement that two ports are connected to the same net.
+    // So, we can iterate over connections (that are digitalWires) and build nets by following these steps:
+    // * Translate each schematic Port to a netlist Port corresponding to an existing primitive.
+    // * CASE 1: If both ports are part of a net, nothing to do.
+    // * CASE 2: If neither port is part of a net, create a new net and attach both ports to it.
+    // * CASE 3: If one port is part of a net and the other is not, attach the unconnected port to the same net as the other port.
+    for(Map.Entry<String, Connection> e : schematic.getConnections().entrySet()){
+      String connectionName = e.getKey();
+      Connection connection = e.getValue();
+      // check type
+      if(!connection.getType().equals(wireConnectionType)){
+        // FIXME subclass this
+        throw new SchematicConstructionException("connection '" + connectionName + "' has unknown type");
+      }
+      
+      org.manifold.intermediate.Port schematicPortFrom = connection.getFrom();
+      if(! (schematicPortFrom.getType().equals(inPortType) || schematicPortFrom.getType().equals(outPortType))){
+        // FIXME subclass this
+        throw new SchematicConstructionException("'from' port on connection '" + connectionName + "' has unknown type");
+      }
+      org.manifold.intermediate.Port schematicPortTo = connection.getTo();
+      if(! (schematicPortTo.getType().equals(inPortType) || schematicPortTo.getType().equals(outPortType))){
+        // FIXME subclass this
+        throw new SchematicConstructionException("'to' port on connection '" + connectionName + "' has unknown type");
+      }
+      
+      Port netlistPortFrom = translatePort(schematicPortFrom);
+      Port netlistPortTo = translatePort(schematicPortTo);
+      
+      Net netFrom = netlistPortFrom.getNet();
+      Net netTo = netlistPortTo.getNet();
+      
+      if(netFrom == null){
+        // portFrom is not connected to a net
+        if(netTo == null){
+          // portTo is not connected to a net
+          // CASE 2: neither port is part of a net
+          Net n = new Net(connectionName);
+          n.addPort(netlistPortFrom);
+          n.addPort(netlistPortTo);
+        }else{
+          // portTo is connected to a net
+          // CASE 3: one port is connected and the other is not
+          netlistPortTo.getNet().addPort(netlistPortFrom);
+        }
+      }else{
+        // portFrom is connected to a net
+        if(netTo == null){
+          // portTo is not connected to a net
+          // CASE 3: one port is connected and the other is not
+          netlistPortFrom.getNet().addPort(netlistPortTo);
+        }else{
+          // portTo is connected to a net
+          // CASE 1: both ports are connected
+          // do nothing (this may be an error in later DRC)
+        }
+      }
+      
+    }
+  }
+  
+  /**
+   * Translate a schematic port to a netlist port.
+   * Each Port knows its parent Node; we have a map from Node to Primitive; and if we can get the name of
+   * the Port from its Node, we can use that name to find the corresponding Port in the Primitive.
+   * @throws SchematicConstructionException 
+   */
+  private Port translatePort(org.manifold.intermediate.Port schPort) throws SchematicConstructionException{
+    Node schParentNode = schPort.getParent();
+    Primitive primitive = translatedPrimitives.get(schParentNode);
+    String portName;
+    try{
+      portName = schParentNode.getPortName(schPort);
+    }catch(UndeclaredIdentifierException uie){
+      throw new SchematicConstructionException("internal error: unable to look up name of port belonging to node");
+    }
+    Port primitivePort = primitive.getPort(portName);
+    return primitivePort;
+  }
+  
+}

--- a/src/main/java/org/manifold/backend/digital/Netlist.java
+++ b/src/main/java/org/manifold/backend/digital/Netlist.java
@@ -3,6 +3,7 @@ package org.manifold.backend.digital;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -81,8 +82,12 @@ public class Netlist {
       String nodeName = e.getKey();
       Node node = e.getValue();
       NodeType nodeType = (NodeType)node.getType();
-      Primitive prim = primitiveConstructor.get(nodeType).apply(nodeName, node);
-      translatedPrimitives.put(node, prim);
+      if(primitiveConstructor.containsKey(nodeType)){
+        Primitive prim = primitiveConstructor.get(nodeType).apply(nodeName, node);
+        translatedPrimitives.put(node, prim);
+      }else{
+        throw new NetlistConstructionException("node '" + nodeName + "' has unknown type");
+      }
     }
     
     // Every digitalWire in the schematic is a statement that two ports are connected to the same net.
@@ -155,7 +160,7 @@ public class Netlist {
     String portName;
     try{
       portName = schParentNode.getPortName(schPort);
-    }catch(UndeclaredIdentifierException uie){
+    }catch(NoSuchElementException nsee){
       throw new NetlistConstructionException("internal error: unable to look up name of port belonging to node");
     }
     Port primitivePort = primitive.getPort(portName);

--- a/src/main/java/org/manifold/backend/digital/Netlist.java
+++ b/src/main/java/org/manifold/backend/digital/Netlist.java
@@ -48,6 +48,7 @@ public class Netlist {
   
   public Netlist(Schematic schematic) throws NetlistConstructionException{
     // start by examining the Schematic's definitions for certain node types we are interested in seeing
+    
     try{
       primitiveConstructor.put(schematic.getNodeType("register"), (name, node) -> {
         return new RegisterPrimitive(name, node);
@@ -168,3 +169,4 @@ public class Netlist {
   }
   
 }
+// CHECKSTYLE:ON

--- a/src/main/java/org/manifold/backend/digital/Netlist.java
+++ b/src/main/java/org/manifold/backend/digital/Netlist.java
@@ -22,7 +22,7 @@ public class Netlist {
   
   @FunctionalInterface
   interface BiFunctionConstructor<T, U, R> {
-    R apply(T t, U u) throws NetlistConstructionException;
+    R apply(T t, U u) throws PrimitiveConstructionException;
   }
   
   /**
@@ -58,7 +58,6 @@ public class Netlist {
         return new OutputPinPrimitive(name, node);
       });
     }catch(UndeclaredIdentifierException uie){
-      // FIXME subclass this and make a more specific exception
       throw new NetlistConstructionException(uie.getMessage() + " while searching for node types");
     }
     
@@ -66,7 +65,6 @@ public class Netlist {
     try{
       wireConnectionType = schematic.getConnectionType("digitalWire");
     }catch(UndeclaredIdentifierException uie){
-      // FIXME subclass this
       throw new NetlistConstructionException(uie.getMessage() + " while searching for connection types");
     }
     
@@ -75,7 +73,6 @@ public class Netlist {
       inPortType = schematic.getPortType("digitalIn");
       outPortType = schematic.getPortType("digitalOut");
     }catch(UndeclaredIdentifierException uie){
-      // FIXME subclass this
       throw new NetlistConstructionException(uie.getMessage() + " while searching for port types");
     }
     
@@ -99,18 +96,15 @@ public class Netlist {
       Connection connection = e.getValue();
       // check type
       if(!connection.getType().equals(wireConnectionType)){
-        // FIXME subclass this
         throw new NetlistConstructionException("connection '" + connectionName + "' has unknown type");
       }
       
       org.manifold.intermediate.Port schematicPortFrom = connection.getFrom();
       if(! (schematicPortFrom.getType().equals(inPortType) || schematicPortFrom.getType().equals(outPortType))){
-        // FIXME subclass this
         throw new NetlistConstructionException("'from' port on connection '" + connectionName + "' has unknown type");
       }
       org.manifold.intermediate.Port schematicPortTo = connection.getTo();
       if(! (schematicPortTo.getType().equals(inPortType) || schematicPortTo.getType().equals(outPortType))){
-        // FIXME subclass this
         throw new NetlistConstructionException("'to' port on connection '" + connectionName + "' has unknown type");
       }
       

--- a/src/main/java/org/manifold/backend/digital/NetlistConstructionException.java
+++ b/src/main/java/org/manifold/backend/digital/NetlistConstructionException.java
@@ -1,10 +1,10 @@
 package org.manifold.backend.digital;
 
-public class SchematicConstructionException extends Exception {
+public class NetlistConstructionException extends Exception {
   private static final long serialVersionUID = 8069548761921986148L;
 
   private String reason;
-  public SchematicConstructionException(String reason){
+  public NetlistConstructionException(String reason){
     this.reason = reason;
   }
   

--- a/src/main/java/org/manifold/backend/digital/OutputPinPrimitive.java
+++ b/src/main/java/org/manifold/backend/digital/OutputPinPrimitive.java
@@ -1,0 +1,16 @@
+package org.manifold.backend.digital;
+
+import org.manifold.backend.digital.Port.PortDirection;
+import org.manifold.intermediate.Node;
+
+public class OutputPinPrimitive extends Primitive {
+
+  private Port in = new Port("in", PortDirection.INPUT);
+  
+  public OutputPinPrimitive(String name, Node node){
+    super(name);
+    
+    addPort(in);
+  }
+  
+}

--- a/src/main/java/org/manifold/backend/digital/Port.java
+++ b/src/main/java/org/manifold/backend/digital/Port.java
@@ -19,9 +19,10 @@ public class Port {
   public Net getNet(){
     return attachedNet;
   }
-  public void setNet(Net net){
+  public void setNet(Net net) throws NetlistConstructionException{
     if(attachedNet != null){
-      attachedNet.removePort(this);
+      // FIXME subclass this
+      throw new NetlistConstructionException("attempted to set net twice on port '" + name + "'");
     }
     attachedNet = net;
   }

--- a/src/main/java/org/manifold/backend/digital/Port.java
+++ b/src/main/java/org/manifold/backend/digital/Port.java
@@ -1,0 +1,33 @@
+package org.manifold.backend.digital;
+
+public class Port {
+  
+  enum PortDirection {
+    INPUT,
+    OUTPUT,
+  }
+  
+  private String name;
+  public String getName(){
+    return name;
+  }
+  private PortDirection direction;
+  public PortDirection getDirection(){
+    return direction;
+  }
+  private Net attachedNet = null;
+  public Net getNet(){
+    return attachedNet;
+  }
+  public void setNet(Net net){
+    if(attachedNet != null){
+      attachedNet.removePort(this);
+    }
+    attachedNet = net;
+  }
+  
+  public Port(String name, PortDirection direction){
+    this.name = name;
+    this.direction = direction;
+  }
+}

--- a/src/main/java/org/manifold/backend/digital/Port.java
+++ b/src/main/java/org/manifold/backend/digital/Port.java
@@ -21,7 +21,6 @@ public class Port {
   }
   public void setNet(Net net) throws NetlistConstructionException{
     if(attachedNet != null){
-      // FIXME subclass this
       throw new NetlistConstructionException("attempted to set net twice on port '" + name + "'");
     }
     attachedNet = net;

--- a/src/main/java/org/manifold/backend/digital/Port.java
+++ b/src/main/java/org/manifold/backend/digital/Port.java
@@ -20,8 +20,9 @@ public class Port {
     return attachedNet;
   }
   public void setNet(Net net) throws NetlistConstructionException{
-    if(attachedNet != null){
-      throw new NetlistConstructionException("attempted to set net twice on port '" + name + "'");
+    if (attachedNet != null){
+      throw new NetlistConstructionException(
+          "attempted to set net twice on port '" + name + "'");
     }
     attachedNet = net;
   }

--- a/src/main/java/org/manifold/backend/digital/Primitive.java
+++ b/src/main/java/org/manifold/backend/digital/Primitive.java
@@ -16,9 +16,12 @@ public abstract class Primitive {
     ports.put(p.getName(), p);
   }
   
-  public Port getPort(String portName){
-    // FIXME what if it doesn't exist?
-    return ports.get(portName);
+  public Port getPort(String portName) throws UndeclaredIdentifierException{
+    if(ports.containsKey(portName)){
+      return ports.get(portName);
+    }else{
+      throw new UndeclaredIdentifierException(portName);
+    }
   }
   
   public Collection<Port> getPorts(){

--- a/src/main/java/org/manifold/backend/digital/Primitive.java
+++ b/src/main/java/org/manifold/backend/digital/Primitive.java
@@ -17,9 +17,9 @@ public abstract class Primitive {
   }
   
   public Port getPort(String portName) throws UndeclaredIdentifierException{
-    if(ports.containsKey(portName)){
+    if (ports.containsKey(portName)){
       return ports.get(portName);
-    }else{
+    } else {
       throw new UndeclaredIdentifierException(portName);
     }
   }

--- a/src/main/java/org/manifold/backend/digital/Primitive.java
+++ b/src/main/java/org/manifold/backend/digital/Primitive.java
@@ -1,0 +1,32 @@
+package org.manifold.backend.digital;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class Primitive {
+  private String name;
+  public String getName(){
+    return name;
+  }
+  
+  private Map<String, Port> ports = new HashMap<String, Port>();
+  
+  public void addPort(Port p){
+    ports.put(p.getName(), p);
+  }
+  
+  public Port getPort(String portName){
+    // FIXME what if it doesn't exist?
+    return ports.get(portName);
+  }
+  
+  public Collection<Port> getPorts(){
+    return java.util.Collections.unmodifiableCollection(ports.values());
+  }
+
+  public Primitive(String name){
+    this.name = name;
+  }
+  
+}

--- a/src/main/java/org/manifold/backend/digital/PrimitiveConstructionException.java
+++ b/src/main/java/org/manifold/backend/digital/PrimitiveConstructionException.java
@@ -1,0 +1,10 @@
+package org.manifold.backend.digital;
+
+public class PrimitiveConstructionException extends
+    NetlistConstructionException {
+
+  public PrimitiveConstructionException(String reason) {
+    super(reason);
+  }
+
+}

--- a/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
+++ b/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
@@ -28,7 +28,7 @@ public class RegisterPrimitive extends Primitive {
     return clockActiveHigh;
   }
   
-  public RegisterPrimitive(String name, Node node) throws SchematicConstructionException{
+  public RegisterPrimitive(String name, Node node) throws NetlistConstructionException{
     super(name);
     
     try{
@@ -38,7 +38,7 @@ public class RegisterPrimitive extends Primitive {
       clockActiveHigh = ((BooleanValue)node.getAttribute("clockActiveHigh")).getValue();
     }catch(UndeclaredAttributeException uae){
       // FIXME subclass this
-      throw new SchematicConstructionException("error while setting attributes of register '" + getName() + "'");
+      throw new NetlistConstructionException("error while setting attributes of register '" + getName() + "'");
     }
     
     addPort(port_in);

--- a/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
+++ b/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
@@ -1,0 +1,49 @@
+package org.manifold.backend.digital;
+
+import org.manifold.backend.digital.Port.PortDirection;
+import org.manifold.intermediate.BooleanValue;
+import org.manifold.intermediate.Node;
+import org.manifold.intermediate.UndeclaredAttributeException;
+
+public class RegisterPrimitive extends Primitive {
+  private Port port_in = new Port("in", PortDirection.INPUT);
+  private Port port_out = new Port("out", PortDirection.OUTPUT);
+  private Port port_clock = new Port("clock", PortDirection.INPUT);
+  private Port port_reset = new Port("reset", PortDirection.INPUT);
+  
+  private boolean initialValue;
+  public boolean isInitialValueHigh(){
+    return initialValue;
+  }
+  private boolean resetActiveHigh;
+  public boolean isResetActiveHigh(){
+    return resetActiveHigh;
+  }
+  private boolean resetAsynchronous;
+  public boolean isResetAsynchronous(){
+    return resetAsynchronous;
+  }
+  private boolean clockActiveHigh;
+  public boolean isClockActiveHigh(){
+    return clockActiveHigh;
+  }
+  
+  public RegisterPrimitive(String name, Node node) throws SchematicConstructionException{
+    super(name);
+    
+    try{
+      initialValue = ((BooleanValue)node.getAttribute("initialValue")).getValue();
+      resetActiveHigh = ((BooleanValue)node.getAttribute("resetActiveHigh")).getValue();
+      resetAsynchronous = ((BooleanValue)node.getAttribute("resetAsynchronous")).getValue();
+      clockActiveHigh = ((BooleanValue)node.getAttribute("clockActiveHigh")).getValue();
+    }catch(UndeclaredAttributeException uae){
+      // FIXME subclass this
+      throw new SchematicConstructionException("error while setting attributes of register '" + getName() + "'");
+    }
+    
+    addPort(port_in);
+    addPort(port_out);
+    addPort(port_clock);
+    addPort(port_reset);
+  }
+}

--- a/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
+++ b/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
@@ -28,16 +28,22 @@ public class RegisterPrimitive extends Primitive {
     return clockActiveHigh;
   }
   
-  public RegisterPrimitive(String name, Node node) throws PrimitiveConstructionException{
+  public RegisterPrimitive(String name, Node node) 
+      throws PrimitiveConstructionException{
     super(name);
     
-    try{
-      initialValue = ((BooleanValue)node.getAttribute("initialValue")).getValue();
-      resetActiveHigh = ((BooleanValue)node.getAttribute("resetActiveHigh")).getValue();
-      resetAsynchronous = ((BooleanValue)node.getAttribute("resetAsynchronous")).getValue();
-      clockActiveHigh = ((BooleanValue)node.getAttribute("clockActiveHigh")).getValue();
-    }catch(UndeclaredAttributeException uae){
-      throw new PrimitiveConstructionException("error while setting attributes of register '" + getName() + "'");
+    try {
+      initialValue = ((BooleanValue) 
+          node.getAttribute("initialValue")).getValue();
+      resetActiveHigh = ((BooleanValue) 
+          node.getAttribute("resetActiveHigh")).getValue();
+      resetAsynchronous = ((BooleanValue) 
+          node.getAttribute("resetAsynchronous")).getValue();
+      clockActiveHigh = ((BooleanValue) 
+          node.getAttribute("clockActiveHigh")).getValue();
+    } catch (UndeclaredAttributeException uae) {
+      throw new PrimitiveConstructionException(
+          "error while setting attributes of register '" + getName() + "'");
     }
     
     addPort(port_in);

--- a/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
+++ b/src/main/java/org/manifold/backend/digital/RegisterPrimitive.java
@@ -28,7 +28,7 @@ public class RegisterPrimitive extends Primitive {
     return clockActiveHigh;
   }
   
-  public RegisterPrimitive(String name, Node node) throws NetlistConstructionException{
+  public RegisterPrimitive(String name, Node node) throws PrimitiveConstructionException{
     super(name);
     
     try{
@@ -37,8 +37,7 @@ public class RegisterPrimitive extends Primitive {
       resetAsynchronous = ((BooleanValue)node.getAttribute("resetAsynchronous")).getValue();
       clockActiveHigh = ((BooleanValue)node.getAttribute("clockActiveHigh")).getValue();
     }catch(UndeclaredAttributeException uae){
-      // FIXME subclass this
-      throw new NetlistConstructionException("error while setting attributes of register '" + getName() + "'");
+      throw new PrimitiveConstructionException("error while setting attributes of register '" + getName() + "'");
     }
     
     addPort(port_in);

--- a/src/main/java/org/manifold/backend/digital/SchematicConstructionException.java
+++ b/src/main/java/org/manifold/backend/digital/SchematicConstructionException.java
@@ -1,0 +1,16 @@
+package org.manifold.backend.digital;
+
+public class SchematicConstructionException extends Exception {
+  private static final long serialVersionUID = 8069548761921986148L;
+
+  private String reason;
+  public SchematicConstructionException(String reason){
+    this.reason = reason;
+  }
+  
+  @Override
+  public String getMessage(){
+    return "could not construct schematic: " + reason;
+  }
+  
+}

--- a/src/main/java/org/manifold/backend/digital/UndeclaredIdentifierException.java
+++ b/src/main/java/org/manifold/backend/digital/UndeclaredIdentifierException.java
@@ -1,0 +1,11 @@
+package org.manifold.backend.digital;
+
+public class UndeclaredIdentifierException extends NetlistConstructionException {
+
+  private static final long serialVersionUID = 1596430164652515640L;
+
+  public UndeclaredIdentifierException(String identifier) {
+    super("undeclared identifier '" + identifier + "'");
+  }
+
+}

--- a/src/main/java/org/manifold/backend/digital/UndeclaredIdentifierException.java
+++ b/src/main/java/org/manifold/backend/digital/UndeclaredIdentifierException.java
@@ -1,6 +1,7 @@
 package org.manifold.backend.digital;
 
-public class UndeclaredIdentifierException extends NetlistConstructionException {
+public class UndeclaredIdentifierException 
+  extends NetlistConstructionException {
 
   private static final long serialVersionUID = 1596430164652515640L;
 

--- a/src/main/java/org/manifold/intermediate/BooleanValue.java
+++ b/src/main/java/org/manifold/intermediate/BooleanValue.java
@@ -7,5 +7,9 @@ public class BooleanValue extends Value {
     super(t);
     this.val = val;
   }
+  
+  public boolean getValue(){
+    return val;
+  }
 
 }

--- a/src/main/java/org/manifold/intermediate/Node.java
+++ b/src/main/java/org/manifold/intermediate/Node.java
@@ -24,9 +24,9 @@ public class Node extends Value {
   }
 
   public String getPortName(Port port) throws NoSuchElementException {
-    if(reversePorts.containsKey(port)){
+    if (reversePorts.containsKey(port)){
       return reversePorts.get(port);
-    }else{
+    } else {
       throw new NoSuchElementException();
     }
   }

--- a/src/main/java/org/manifold/intermediate/Node.java
+++ b/src/main/java/org/manifold/intermediate/Node.java
@@ -2,6 +2,7 @@ package org.manifold.intermediate;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 public class Node extends Value {
 
@@ -22,12 +23,11 @@ public class Node extends Value {
     }
   }
 
-  public String getPortName(Port port) throws UndeclaredIdentifierException{
+  public String getPortName(Port port) throws NoSuchElementException {
     if(reversePorts.containsKey(port)){
       return reversePorts.get(port);
     }else{
-      // FIXME this is NOT the right exception to throw!
-      throw new UndeclaredIdentifierException("no such port");
+      throw new NoSuchElementException();
     }
   }
 

--- a/src/main/java/org/manifold/intermediate/Node.java
+++ b/src/main/java/org/manifold/intermediate/Node.java
@@ -7,6 +7,7 @@ public class Node extends Value {
 
   private final Attributes attributes;
   private final Map<String, Port> ports;
+  private final Map<Port, String> reversePorts;
 
   public Value getAttribute(String attrName)
       throws UndeclaredAttributeException {
@@ -27,6 +28,15 @@ public class Node extends Value {
       );
     }
   }
+  public String getPortName(Port port) throws UndeclaredIdentifierException{
+    if(reversePorts.containsKey(port)){
+      return reversePorts.get(port);
+    }else{
+      // FIXME this is NOT the right exception to throw!
+      throw new UndeclaredIdentifierException("no such port");
+    }
+  }
+  
   public void setPortAttributes(
       String portName,
       String attrName,
@@ -46,13 +56,16 @@ public class Node extends Value {
     super(type);
     this.attributes = new Attributes();
     this.ports = new HashMap<>();
+    this.reversePorts = new HashMap<>();
 
     if (type.getPorts() != null) {
       for (Map.Entry<String, PortType> portEntry : type.getPorts().entrySet()) {
+        Port p = new Port(portEntry.getValue(), this); 
         this.ports.put(
           portEntry.getKey(),
-          new Port(portEntry.getValue(), this)
+          p
         );
+        this.reversePorts.put(p, portEntry.getKey());
       }
     }
   }

--- a/src/main/java/org/manifold/intermediate/Schematic.java
+++ b/src/main/java/org/manifold/intermediate/Schematic.java
@@ -28,8 +28,16 @@ public class Schematic {
   // Maps containing instantiated objects for this schematic; they are all
   // indexed by the (string) instance-name of the object.
   private final Map<String, Node> nodes;
+  public Map<String, Node> getNodes(){
+    return java.util.Collections.unmodifiableMap(nodes);
+  }
+  
   private final Map<Node, String> reverseNodeMap;
   private final Map<String, Connection> connections;
+  public Map<String, Connection> getConnections(){
+    return java.util.Collections.unmodifiableMap(connections);
+  }
+  
   private final Map<String, Constraint> constraints;
 
   public Schematic(String name) {

--- a/src/test/java/org/manifold/backend/digital/TestNet.java
+++ b/src/test/java/org/manifold/backend/digital/TestNet.java
@@ -1,0 +1,42 @@
+package org.manifold.backend.digital;
+
+import static org.junit.Assert.*;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.manifold.backend.digital.Port.PortDirection;
+
+public class TestNet {
+
+  @Test
+  public void testGetName() {
+    String name = "n_test";
+    Net n = new Net(name);
+    assertEquals(name, n.getName());
+  }
+  
+  @Test
+  public void testAddPort() throws NetlistConstructionException {
+    Port p = new Port("test", PortDirection.INPUT);
+    Net n = new Net("n_test");
+    n.addPort(p);
+  }
+  
+  @Test
+  public void testGetPorts_InitiallyEmpty(){
+    Net n = new Net("n_test");
+    Set<Port> ports = n.getPorts();
+    assertTrue(ports.isEmpty());
+  }
+  
+  @Test
+  public void testGetPorts_ContainsAddedPort() throws NetlistConstructionException{
+    Net n = new Net("n_test");
+    Port p = new Port("test", PortDirection.INPUT);
+    n.addPort(p);
+    Set<Port> ports = n.getPorts();
+    assertTrue(ports.contains(p));
+  }
+
+}

--- a/src/test/java/org/manifold/backend/digital/TestNet.java
+++ b/src/test/java/org/manifold/backend/digital/TestNet.java
@@ -31,7 +31,8 @@ public class TestNet {
   }
   
   @Test
-  public void testGetPorts_ContainsAddedPort() throws NetlistConstructionException{
+  public void testGetPorts_ContainsAddedPort() 
+      throws NetlistConstructionException {
     Net n = new Net("n_test");
     Port p = new Port("test", PortDirection.INPUT);
     n.addPort(p);

--- a/src/test/java/org/manifold/backend/digital/TestNetlist.java
+++ b/src/test/java/org/manifold/backend/digital/TestNetlist.java
@@ -36,17 +36,23 @@ public class TestNetlist {
   private static PortType digitalInPortType;
   private static PortType digitalOutPortType;
   
-  private static final Map<String, Type> noTypeAttributes = new HashMap<String,Type>();
-  private static final Map<String, Value> noAttributes = new HashMap<>();
+  private static final Map<String, Type> noTypeAttributes 
+    = new HashMap<String, Type>();
+  private static final Map<String, Value> noAttributes 
+    = new HashMap<>();
   
-  private static Map<String, Type> registerTypeAttributes = new HashMap<String, Type>();
-  private static Map<String, PortType> registerTypePorts = new HashMap<String, PortType>();
+  private static Map<String, Type> registerTypeAttributes 
+    = new HashMap<String, Type>();
+  private static Map<String, PortType> registerTypePorts 
+    = new HashMap<String, PortType>();
   private static NodeType registerType;
   
-  private static Map<String, PortType> inputPinTypePorts = new HashMap<String, PortType>();
+  private static Map<String, PortType> inputPinTypePorts 
+    = new HashMap<String, PortType>();
   private static NodeType inputPinType;
   
-  private static Map<String, PortType> outputPinTypePorts = new HashMap<String, PortType>();
+  private static Map<String, PortType> outputPinTypePorts 
+    = new HashMap<String, PortType>();
   private static NodeType outputPinType;
   
   private static ConnectionType digitalWireType;
@@ -78,25 +84,28 @@ public class TestNetlist {
   }
   
   /**
-   * Instantiate a Schematic, but with varying degrees of "completeness" in terms of
-   * what object types are included. If types are missing, it will not be possible
-   * to construct a Netlist.
+   * Instantiate a Schematic, but with varying degrees of "completeness" 
+   * in terms of what object types are included. If types are missing, 
+   * it will not be possible to construct a Netlist.
    * @throws MultipleDefinitionException 
    */
-  public static Schematic instantiateSchematic(String name, boolean includePortTypes, boolean includeNodeTypes, boolean includeConnectionTypes) throws MultipleDefinitionException{
+  public static Schematic instantiateSchematic(String name, 
+      boolean includePortTypes, boolean includeNodeTypes, 
+      boolean includeConnectionTypes) 
+      throws MultipleDefinitionException {
     Schematic s = new Schematic(name);
-    if(includePortTypes){
+    if (includePortTypes) {
       s.addPortType("digitalIn", digitalInPortType);
       s.addPortType("digitalOut", digitalOutPortType);
     }
     
-    if(includeNodeTypes){
+    if (includeNodeTypes) {
       s.addNodeType("register", registerType);
       s.addNodeType("inputPin", inputPinType);
       s.addNodeType("outputPin", outputPinType);
     }
     
-    if(includeConnectionTypes){
+    if (includeConnectionTypes) {
       s.addConnectionType("digitalWire", digitalWireType);
     }
     
@@ -106,16 +115,24 @@ public class TestNetlist {
   /**
    * Instantiate a Schematic and include all object types.
    */
-  public static Schematic instantiateSchematic(String name) throws MultipleDefinitionException{
+  public static Schematic instantiateSchematic(String name) 
+      throws MultipleDefinitionException {
     return instantiateSchematic(name, true, true, true);
   }
   
-  public static Node instantiateRegister(boolean initialValue, boolean resetActiveHigh, boolean resetAsynchronous, boolean clockActiveHigh) throws SchematicException{
+  public static Node instantiateRegister(boolean initialValue, 
+      boolean resetActiveHigh, boolean resetAsynchronous, 
+      boolean clockActiveHigh) 
+      throws SchematicException {
     Map<String, Value> registerAttrs = new HashMap<>();
-    registerAttrs.put("initialValue", new BooleanValue(BooleanType.getInstance(), initialValue));
-    registerAttrs.put("resetActiveHigh", new BooleanValue(BooleanType.getInstance(), resetActiveHigh));
-    registerAttrs.put("resetAsynchronous", new BooleanValue(BooleanType.getInstance(), resetAsynchronous));
-    registerAttrs.put("clockActiveHigh", new BooleanValue(BooleanType.getInstance(), clockActiveHigh));
+    registerAttrs.put("initialValue", 
+        new BooleanValue(BooleanType.getInstance(), initialValue));
+    registerAttrs.put("resetActiveHigh", 
+        new BooleanValue(BooleanType.getInstance(), resetActiveHigh));
+    registerAttrs.put("resetAsynchronous", 
+        new BooleanValue(BooleanType.getInstance(), resetAsynchronous));
+    registerAttrs.put("clockActiveHigh", 
+        new BooleanValue(BooleanType.getInstance(), clockActiveHigh));
     Map<String, Map<String, Value>> registerPortAttrs = new HashMap<>();
     registerPortAttrs.put("in", noAttributes);
     registerPortAttrs.put("out", noAttributes);
@@ -139,7 +156,9 @@ public class TestNetlist {
     return outputPin;
   }
   
-  public static Connection instantiateWire(org.manifold.intermediate.Port from, org.manifold.intermediate.Port to) throws UndeclaredAttributeException, InvalidAttributeException{
+  public static Connection instantiateWire(
+      org.manifold.intermediate.Port from, org.manifold.intermediate.Port to) 
+      throws UndeclaredAttributeException, InvalidAttributeException{
     Connection wire = new Connection(digitalWireType, from, to, noAttributes);
     return wire;
   }
@@ -147,7 +166,8 @@ public class TestNetlist {
   // parameterized test cases
   
   @Parameters
-  public static Collection<Object[]> testSchematics() throws SchematicException {
+  public static Collection<Object[]> testSchematics() 
+      throws SchematicException {
     List<Object[]> data = new LinkedList<Object[]>();
     
     // BEGIN CASE 0
@@ -156,7 +176,8 @@ public class TestNetlist {
       Schematic case0 = instantiateSchematic("case0");
       Node in = instantiateInputPin();
       Node out = instantiateOutputPin();
-      Connection in_to_out = instantiateWire(in.getPort("out"), out.getPort("in"));
+      Connection in_to_out = instantiateWire(
+          in.getPort("out"), out.getPort("in"));
       case0.addNode("in", in);
       case0.addNode("out", out);
       case0.addConnection("in_to_out", in_to_out);
@@ -189,19 +210,20 @@ public class TestNetlist {
   @Test
   public void testPrimitiveTranslation_IsOnto(){
     Map<String, Boolean> checklist = new HashMap<String, Boolean>();
-    for(Primitive prim : _netlist.getPrimitives()){
+    for (Primitive prim : _netlist.getPrimitives()){
       checklist.put(prim.getName(), false);
     }
     
-    for(String nodeName : _schematic.getNodes().keySet()){
-      if(checklist.containsKey(nodeName)){
+    for (String nodeName : _schematic.getNodes().keySet()){
+      if (checklist.containsKey(nodeName)){
         checklist.put(nodeName, true);
       }
     }
     
-    for(Map.Entry<String, Boolean> entry : checklist.entrySet()){
-      if(entry.getValue() == false){
-        fail("no corresponding node found for primitive '" + entry.getKey() + "'");
+    for (Map.Entry<String, Boolean> entry : checklist.entrySet()){
+      if (entry.getValue() == false){
+        fail("no corresponding node found for primitive '" 
+          + entry.getKey() + "'");
       }
     }
   }
@@ -214,21 +236,22 @@ public class TestNetlist {
   public void testPrimitiveTranslation_IsOneToOne(){
     Map<String, Boolean> checklist = new HashMap<String, Boolean>();
     
-    for(Map.Entry<String, Node> nodeEntry : _schematic.getNodes().entrySet()){
+    for (Map.Entry<String, Node> nodeEntry : _schematic.getNodes().entrySet()){
       String nodeName = nodeEntry.getKey();
       Node node = nodeEntry.getValue();
       checklist.put(nodeName, false);
     }
     
-    for(Primitive prim : _netlist.getPrimitives()){
-      if(checklist.containsKey(prim.getName())){
+    for (Primitive prim : _netlist.getPrimitives()){
+      if (checklist.containsKey(prim.getName())){
         checklist.put(prim.getName(), true);
       }
     }
     
-    for(Map.Entry<String, Boolean> entry : checklist.entrySet()){
-      if(entry.getValue() == false){
-        fail("no corresponding primitive found for node '" + entry.getKey() + "'");
+    for (Map.Entry<String, Boolean> entry : checklist.entrySet()){
+      if (entry.getValue() == false){
+        fail("no corresponding primitive found for node '" 
+          + entry.getKey() + "'");
       }
     }
   }

--- a/src/test/java/org/manifold/backend/digital/TestNetlist.java
+++ b/src/test/java/org/manifold/backend/digital/TestNetlist.java
@@ -1,0 +1,201 @@
+package org.manifold.backend.digital;
+
+import static org.junit.Assert.*;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.manifold.intermediate.BooleanType;
+import org.manifold.intermediate.BooleanValue;
+import org.manifold.intermediate.Connection;
+import org.manifold.intermediate.ConnectionType;
+import org.manifold.intermediate.MultipleAssignmentException;
+import org.manifold.intermediate.MultipleDefinitionException;
+import org.manifold.intermediate.Node;
+import org.manifold.intermediate.NodeType;
+import org.manifold.intermediate.PortType;
+import org.manifold.intermediate.Schematic;
+import org.manifold.intermediate.Type;
+import org.manifold.intermediate.UndeclaredIdentifierException;
+
+@RunWith(value = Parameterized.class)
+public class TestNetlist {
+  
+  private static PortType digitalInPortType;
+  private static PortType digitalOutPortType;
+  
+  private static final Map<String, Type> noAttributes = new HashMap<String,Type>();
+  
+  private static Map<String, Type> registerTypeAttributes = new HashMap<String, Type>();
+  private static Map<String, PortType> registerTypePorts = new HashMap<String, PortType>();
+  private static NodeType registerType;
+  
+  private static Map<String, PortType> inputPinTypePorts = new HashMap<String, PortType>();
+  private static NodeType inputPinType;
+  
+  private static Map<String, PortType> outputPinTypePorts = new HashMap<String, PortType>();
+  private static NodeType outputPinType;
+  
+  private static ConnectionType digitalWireType;
+  
+  
+  @BeforeClass
+  public static void setupIntermediateTypes(){
+    
+    digitalInPortType = new PortType(noAttributes);
+    digitalOutPortType = new PortType(noAttributes);
+    
+    registerTypeAttributes.put("initialValue", BooleanType.getInstance());
+    registerTypeAttributes.put("resetActiveHigh", BooleanType.getInstance());
+    registerTypeAttributes.put("resetAsynchronous", BooleanType.getInstance());
+    registerTypeAttributes.put("clockActiveHigh", BooleanType.getInstance());
+    registerTypePorts.put("in", digitalInPortType);
+    registerTypePorts.put("out", digitalOutPortType);
+    registerTypePorts.put("clock", digitalInPortType);
+    registerTypePorts.put("reset", digitalInPortType);
+    registerType = new NodeType(registerTypeAttributes, registerTypePorts);
+    
+    inputPinTypePorts.put("out", digitalOutPortType);
+    inputPinType = new NodeType(noAttributes, inputPinTypePorts);
+    
+    outputPinTypePorts.put("in", digitalInPortType);
+    outputPinType = new NodeType(noAttributes, outputPinTypePorts);
+    
+    digitalWireType = new ConnectionType(noAttributes);
+  }
+  
+  public static Schematic instantiateSchematic(String name) throws MultipleDefinitionException{
+    Schematic s = new Schematic(name);
+    s.addPortType("digitalIn", digitalInPortType);
+    s.addPortType("digitalOut", digitalOutPortType);
+    
+    s.addNodeType("register", registerType);
+    s.addNodeType("inputPin", inputPinType);
+    s.addNodeType("outputPin", outputPinType);
+    
+    s.addConnectionType("digitalWire", digitalWireType);
+    return s;
+  }
+  
+  public static Node instantiateRegister(boolean initialValue, boolean resetActiveHigh, boolean resetAsynchronous, boolean clockActiveHigh){
+    Node register = new Node(registerType);
+    
+    register.setAttribute("initialValue", new BooleanValue(BooleanType.getInstance(), initialValue));
+    register.setAttribute("resetActiveHigh", new BooleanValue(BooleanType.getInstance(), resetActiveHigh));
+    register.setAttribute("resetAsynchronous", new BooleanValue(BooleanType.getInstance(), resetAsynchronous));
+    register.setAttribute("clockActiveHigh", new BooleanValue(BooleanType.getInstance(), clockActiveHigh));
+    
+    return register;
+  }
+  
+  public static Node instantiateInputPin(){
+    Node inputPin = new Node(inputPinType);
+    return inputPin;
+  }
+  
+  public static Node instantiateOutputPin(){
+    Node outputPin = new Node(outputPinType);
+    return outputPin;
+  }
+  
+  public static Connection instantiateWire(org.manifold.intermediate.Port from, org.manifold.intermediate.Port to){
+    Connection wire = new Connection(digitalWireType, from, to);
+    return wire;
+  }
+
+  @Parameters
+  public static Collection<Object[]> testSchematics() throws MultipleDefinitionException, UndeclaredIdentifierException, MultipleAssignmentException {
+    List<Object[]> data = new LinkedList<Object[]>();
+    
+    // BEGIN CASE 0
+    // [digitalIn] -> [digitalOut]
+    {
+      Schematic case0 = instantiateSchematic("case0");
+      Node in = instantiateInputPin();
+      Node out = instantiateOutputPin();
+      Connection in_to_out = instantiateWire(in.getPort("out"), out.getPort("in"));
+      case0.addNode("in", in);
+      case0.addNode("out", out);
+      case0.addConnection("in_to_out", in_to_out);
+      
+      Object[] params = { case0, };
+      data.add(params);
+    }
+    // END CASE 1
+    
+    return data;
+  }
+  
+  // per-test input variables
+  private Schematic _schematic;
+  
+  // single-run test output from the constructor
+  private Netlist _netlist;
+  
+  // parameterized test constructor
+  public TestNetlist(Schematic _schematic) throws NetlistConstructionException{
+    this._schematic = _schematic;
+    
+    _netlist = new Netlist(_schematic);
+  }
+  
+  /**
+   * Verify that every netlist primitive was created from a schematic node.
+   */
+  
+  @Test
+  public void testPrimitiveTranslation_IsOnto(){
+    Map<String, Boolean> checklist = new HashMap<String, Boolean>();
+    for(Primitive prim : _netlist.getPrimitives()){
+      checklist.put(prim.getName(), false);
+    }
+    
+    for(String nodeName : _schematic.getNodes().keySet()){
+      if(checklist.containsKey(nodeName)){
+        checklist.put(nodeName, true);
+      }
+    }
+    
+    for(Map.Entry<String, Boolean> entry : checklist.entrySet()){
+      if(entry.getValue() == false){
+        fail("no corresponding node found for primitive '" + entry.getKey() + "'");
+      }
+    }
+  }
+  
+  /**
+   * Verify that every schematic node created a corresponding netlist primitive.
+   */
+  
+  @Test
+  public void testPrimitiveTranslation_IsOneToOne(){
+    Map<String, Boolean> checklist = new HashMap<String, Boolean>();
+    
+    for(Map.Entry<String, Node> nodeEntry : _schematic.getNodes().entrySet()){
+      String nodeName = nodeEntry.getKey();
+      Node node = nodeEntry.getValue();
+      checklist.put(nodeName, false);
+    }
+    
+    for(Primitive prim : _netlist.getPrimitives()){
+      if(checklist.containsKey(prim.getName())){
+        checklist.put(prim.getName(), true);
+      }
+    }
+    
+    for(Map.Entry<String, Boolean> entry : checklist.entrySet()){
+      if(entry.getValue() == false){
+        fail("no corresponding primitive found for node '" + entry.getKey() + "'");
+      }
+    }
+  }
+
+}

--- a/src/test/java/org/manifold/backend/digital/TestNetlist.java
+++ b/src/test/java/org/manifold/backend/digital/TestNetlist.java
@@ -77,17 +77,37 @@ public class TestNetlist {
     digitalWireType = new ConnectionType(noTypeAttributes);
   }
   
-  public static Schematic instantiateSchematic(String name) throws MultipleDefinitionException{
+  /**
+   * Instantiate a Schematic, but with varying degrees of "completeness" in terms of
+   * what object types are included. If types are missing, it will not be possible
+   * to construct a Netlist.
+   * @throws MultipleDefinitionException 
+   */
+  public static Schematic instantiateSchematic(String name, boolean includePortTypes, boolean includeNodeTypes, boolean includeConnectionTypes) throws MultipleDefinitionException{
     Schematic s = new Schematic(name);
-    s.addPortType("digitalIn", digitalInPortType);
-    s.addPortType("digitalOut", digitalOutPortType);
+    if(includePortTypes){
+      s.addPortType("digitalIn", digitalInPortType);
+      s.addPortType("digitalOut", digitalOutPortType);
+    }
     
-    s.addNodeType("register", registerType);
-    s.addNodeType("inputPin", inputPinType);
-    s.addNodeType("outputPin", outputPinType);
+    if(includeNodeTypes){
+      s.addNodeType("register", registerType);
+      s.addNodeType("inputPin", inputPinType);
+      s.addNodeType("outputPin", outputPinType);
+    }
     
-    s.addConnectionType("digitalWire", digitalWireType);
+    if(includeConnectionTypes){
+      s.addConnectionType("digitalWire", digitalWireType);
+    }
+    
     return s;
+  }
+  
+  /**
+   * Instantiate a Schematic and include all object types.
+   */
+  public static Schematic instantiateSchematic(String name) throws MultipleDefinitionException{
+    return instantiateSchematic(name, true, true, true);
   }
   
   public static Node instantiateRegister(boolean initialValue, boolean resetActiveHigh, boolean resetAsynchronous, boolean clockActiveHigh) throws SchematicException{
@@ -124,6 +144,8 @@ public class TestNetlist {
     return wire;
   }
 
+  // parameterized test cases
+  
   @Parameters
   public static Collection<Object[]> testSchematics() throws SchematicException {
     List<Object[]> data = new LinkedList<Object[]>();

--- a/src/test/java/org/manifold/backend/digital/TestNetlist_InvalidSchematics.java
+++ b/src/test/java/org/manifold/backend/digital/TestNetlist_InvalidSchematics.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.manifold.intermediate.Connection;
+import org.manifold.intermediate.ConnectionType;
 import org.manifold.intermediate.MultipleDefinitionException;
 import org.manifold.intermediate.Node;
 import org.manifold.intermediate.NodeType;
@@ -34,7 +36,7 @@ public class TestNetlist_InvalidSchematics {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with missing port types");
     }catch(NetlistConstructionException ex){
-      assertTrue(ex.getMessage().contains("port types"));
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("port types"));
     }
   }
   
@@ -45,7 +47,7 @@ public class TestNetlist_InvalidSchematics {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with missing node types");
     }catch(NetlistConstructionException ex){
-      assertTrue(ex.getMessage().contains("node types"));
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("node types"));
     }
   }
 
@@ -56,7 +58,7 @@ public class TestNetlist_InvalidSchematics {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with missing connection types");
     }catch(NetlistConstructionException ex){
-      assertTrue(ex.getMessage().contains("connection types"));
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("connection types"));
     }
   }
   
@@ -78,8 +80,33 @@ public class TestNetlist_InvalidSchematics {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with unknown node type");
     }catch(NetlistConstructionException ex){
-      assertTrue(ex.getMessage().contains("node"));
-      assertTrue(ex.getMessage().contains("unknown type"));
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("node"));
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("unknown type"));
+    }
+  }
+  
+  @Test
+  public void testInvalidSchematic_UnknownConnectionType() throws SchematicException {
+    Schematic s = TestNetlist.instantiateSchematic("bogus");
+    // now we add an extra connection type
+    Map<String, Type> noTypeAttributes = new HashMap<String,Type>();
+    ConnectionType bogusConnectionType = new ConnectionType(noTypeAttributes);
+    s.addConnectionType("bogus_t", bogusConnectionType);
+    // add two simple nodes and connect them with our extra type
+    Node in = TestNetlist.instantiateInputPin();
+    Node out = TestNetlist.instantiateOutputPin();
+    Map<String, Value> noAttributes = new HashMap<String,Value>();
+    Connection bogus_in_to_out = new Connection(bogusConnectionType, in.getPort("out"), out.getPort("in"), noAttributes);
+    s.addNode("in", in);
+    s.addNode("out", out);
+    s.addConnection("in_to_out", bogus_in_to_out);
+    
+    try{
+      Netlist netlist = new Netlist(s);
+      fail("schematic constructed with unknown connection type");
+    }catch(NetlistConstructionException ex){
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("connection"));
+      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("unknown type"));
     }
   }
   

--- a/src/test/java/org/manifold/backend/digital/TestNetlist_InvalidSchematics.java
+++ b/src/test/java/org/manifold/backend/digital/TestNetlist_InvalidSchematics.java
@@ -30,35 +30,41 @@ public class TestNetlist_InvalidSchematics {
   }
   
   @Test
-  public void testInvalidSchematic_MissingPortTypes() throws MultipleDefinitionException {
+  public void testInvalidSchematic_MissingPortTypes() 
+      throws MultipleDefinitionException {
     Schematic s = TestNetlist.instantiateSchematic("bogus", false, true, true);
     try {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with missing port types");
-    }catch(NetlistConstructionException ex){
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("port types"));
+    } catch (NetlistConstructionException ex) {
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("port types"));
     }
   }
   
   @Test
-  public void testInvalidSchematic_MissingNodeTypes() throws MultipleDefinitionException {
+  public void testInvalidSchematic_MissingNodeTypes() 
+      throws MultipleDefinitionException {
     Schematic s = TestNetlist.instantiateSchematic("bogus", true, false, true);
     try {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with missing node types");
-    }catch(NetlistConstructionException ex){
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("node types"));
+    } catch (NetlistConstructionException ex) {
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("node types"));
     }
   }
 
   @Test
-  public void testInvalidSchematic_MissingConnectionTypes() throws MultipleDefinitionException {
+  public void testInvalidSchematic_MissingConnectionTypes() 
+      throws MultipleDefinitionException {
     Schematic s = TestNetlist.instantiateSchematic("bogus", true, true, false);
     try {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with missing connection types");
-    }catch(NetlistConstructionException ex){
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("connection types"));
+    } catch (NetlistConstructionException ex) {
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("connection types"));
     }
   }
   
@@ -66,47 +72,53 @@ public class TestNetlist_InvalidSchematics {
   public void testInvalidSchematic_UnknownNodeType() throws SchematicException {
     Schematic s = TestNetlist.instantiateSchematic("bogus");
     // now we add an extra node type
-    Map<String, Type> noTypeAttributes = new HashMap<String,Type>();
+    Map<String, Type> noTypeAttributes = new HashMap<String, Type>();
     Map<String, PortType> noTypePorts = new HashMap<String, PortType>();
     NodeType bogusNodeType = new NodeType(noTypeAttributes, noTypePorts);
     s.addNodeType("bogus_t", bogusNodeType);
     // add a node of our extra type
-    Map<String, Value> noAttributes = new HashMap<String,Value>();
+    Map<String, Value> noAttributes = new HashMap<String, Value>();
     Map<String, Map<String, Value>> noPorts = new HashMap<>();
     Node bogusNode = new Node(bogusNodeType, noAttributes, noPorts);
     s.addNode("bogus", bogusNode);
     
-    try{
+    try {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with unknown node type");
-    }catch(NetlistConstructionException ex){
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("node"));
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("unknown type"));
+    } catch (NetlistConstructionException ex) {
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("node"));
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("unknown type"));
     }
   }
   
   @Test
-  public void testInvalidSchematic_UnknownConnectionType() throws SchematicException {
+  public void testInvalidSchematic_UnknownConnectionType() 
+      throws SchematicException {
     Schematic s = TestNetlist.instantiateSchematic("bogus");
     // now we add an extra connection type
-    Map<String, Type> noTypeAttributes = new HashMap<String,Type>();
+    Map<String, Type> noTypeAttributes = new HashMap<String, Type>();
     ConnectionType bogusConnectionType = new ConnectionType(noTypeAttributes);
     s.addConnectionType("bogus_t", bogusConnectionType);
     // add two simple nodes and connect them with our extra type
     Node in = TestNetlist.instantiateInputPin();
     Node out = TestNetlist.instantiateOutputPin();
-    Map<String, Value> noAttributes = new HashMap<String,Value>();
-    Connection bogus_in_to_out = new Connection(bogusConnectionType, in.getPort("out"), out.getPort("in"), noAttributes);
+    Map<String, Value> noAttributes = new HashMap<String, Value>();
+    Connection bogus_in_to_out = new Connection(bogusConnectionType, 
+        in.getPort("out"), out.getPort("in"), noAttributes);
     s.addNode("in", in);
     s.addNode("out", out);
     s.addConnection("in_to_out", bogus_in_to_out);
     
-    try{
+    try {
       Netlist netlist = new Netlist(s);
       fail("schematic constructed with unknown connection type");
-    }catch(NetlistConstructionException ex){
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("connection"));
-      assertTrue("unexpected message: " + ex.getMessage(), ex.getMessage().contains("unknown type"));
+    } catch (NetlistConstructionException ex) {
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("connection"));
+      assertTrue("unexpected message: " + ex.getMessage(), 
+          ex.getMessage().contains("unknown type"));
     }
   }
   

--- a/src/test/java/org/manifold/backend/digital/TestNetlist_InvalidSchematics.java
+++ b/src/test/java/org/manifold/backend/digital/TestNetlist_InvalidSchematics.java
@@ -1,0 +1,86 @@
+package org.manifold.backend.digital;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.manifold.intermediate.MultipleDefinitionException;
+import org.manifold.intermediate.Node;
+import org.manifold.intermediate.NodeType;
+import org.manifold.intermediate.PortType;
+import org.manifold.intermediate.Schematic;
+import org.manifold.intermediate.SchematicException;
+import org.manifold.intermediate.Type;
+import org.manifold.intermediate.Value;
+
+/**
+ * Test the behaviour of Netlist when given an invalid schematic to work with.
+ */
+
+public class TestNetlist_InvalidSchematics {
+
+  @BeforeClass
+  public static void setup(){
+    TestNetlist.setupIntermediateTypes();
+  }
+  
+  @Test
+  public void testInvalidSchematic_MissingPortTypes() throws MultipleDefinitionException {
+    Schematic s = TestNetlist.instantiateSchematic("bogus", false, true, true);
+    try {
+      Netlist netlist = new Netlist(s);
+      fail("schematic constructed with missing port types");
+    }catch(NetlistConstructionException ex){
+      assertTrue(ex.getMessage().contains("port types"));
+    }
+  }
+  
+  @Test
+  public void testInvalidSchematic_MissingNodeTypes() throws MultipleDefinitionException {
+    Schematic s = TestNetlist.instantiateSchematic("bogus", true, false, true);
+    try {
+      Netlist netlist = new Netlist(s);
+      fail("schematic constructed with missing node types");
+    }catch(NetlistConstructionException ex){
+      assertTrue(ex.getMessage().contains("node types"));
+    }
+  }
+
+  @Test
+  public void testInvalidSchematic_MissingConnectionTypes() throws MultipleDefinitionException {
+    Schematic s = TestNetlist.instantiateSchematic("bogus", true, true, false);
+    try {
+      Netlist netlist = new Netlist(s);
+      fail("schematic constructed with missing connection types");
+    }catch(NetlistConstructionException ex){
+      assertTrue(ex.getMessage().contains("connection types"));
+    }
+  }
+  
+  @Test
+  public void testInvalidSchematic_UnknownNodeType() throws SchematicException {
+    Schematic s = TestNetlist.instantiateSchematic("bogus");
+    // now we add an extra node type
+    Map<String, Type> noTypeAttributes = new HashMap<String,Type>();
+    Map<String, PortType> noTypePorts = new HashMap<String, PortType>();
+    NodeType bogusNodeType = new NodeType(noTypeAttributes, noTypePorts);
+    s.addNodeType("bogus_t", bogusNodeType);
+    // add a node of our extra type
+    Map<String, Value> noAttributes = new HashMap<String,Value>();
+    Map<String, Map<String, Value>> noPorts = new HashMap<>();
+    Node bogusNode = new Node(bogusNodeType, noAttributes, noPorts);
+    s.addNode("bogus", bogusNode);
+    
+    try{
+      Netlist netlist = new Netlist(s);
+      fail("schematic constructed with unknown node type");
+    }catch(NetlistConstructionException ex){
+      assertTrue(ex.getMessage().contains("node"));
+      assertTrue(ex.getMessage().contains("unknown type"));
+    }
+  }
+  
+}

--- a/src/test/java/org/manifold/backend/digital/TestPort.java
+++ b/src/test/java/org/manifold/backend/digital/TestPort.java
@@ -1,0 +1,51 @@
+package org.manifold.backend.digital;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.manifold.backend.digital.Port.PortDirection;
+
+public class TestPort {
+
+  @Test
+  public void testGetName() {
+    String name = "test";
+    Port port = new Port(name, PortDirection.INPUT);
+    assertEquals(name, port.getName());
+  }
+  
+  @Test
+  public void testGetDirection(){
+    PortDirection dir = PortDirection.INPUT;
+    Port port = new Port("test", dir);
+    assertEquals(dir, port.getDirection());
+  }
+  
+  @Test
+  public void testGetNet_NewPort_HasNullNet(){
+    Port port = new Port("test", PortDirection.INPUT);
+    assertNull(port.getNet());
+  }
+  
+  @Test
+  public void testSetNet() throws NetlistConstructionException{
+    Port port = new Port("test", PortDirection.INPUT);
+    Net n = new Net("n_test");
+    port.setNet(n);
+    assertEquals(n, port.getNet());
+  }
+  
+  @Test(expected = NetlistConstructionException.class)
+  public void testSetNet_AlreadySet_ThrowsException() throws NetlistConstructionException{
+    Port port = new Port("test", PortDirection.INPUT);
+    Net n1 = new Net("n1_test");
+    try{
+      port.setNet(n1);
+    }catch(NetlistConstructionException sce){
+      fail("exception thrown too early: " + sce.getMessage());
+    }
+    Net n2 = new Net("n2_test");
+    port.setNet(n2);
+  }
+
+}

--- a/src/test/java/org/manifold/backend/digital/TestPort.java
+++ b/src/test/java/org/manifold/backend/digital/TestPort.java
@@ -36,12 +36,13 @@ public class TestPort {
   }
   
   @Test(expected = NetlistConstructionException.class)
-  public void testSetNet_AlreadySet_ThrowsException() throws NetlistConstructionException{
+  public void testSetNet_AlreadySet_ThrowsException() 
+      throws NetlistConstructionException{
     Port port = new Port("test", PortDirection.INPUT);
     Net n1 = new Net("n1_test");
-    try{
+    try {
       port.setNet(n1);
-    }catch(NetlistConstructionException sce){
+    } catch (NetlistConstructionException sce) {
       fail("exception thrown too early: " + sce.getMessage());
     }
     Net n2 = new Net("n2_test");

--- a/src/test/java/org/manifold/backend/digital/TestPrimitive.java
+++ b/src/test/java/org/manifold/backend/digital/TestPrimitive.java
@@ -1,0 +1,54 @@
+package org.manifold.backend.digital;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.manifold.backend.digital.Port.PortDirection;
+
+public class TestPrimitive {
+
+  class MockPrimitive extends Primitive {
+
+    public MockPrimitive(String name) {
+      super(name);
+    }
+    
+  }
+  
+  @Test
+  public void testGetName() {
+    String name = "test";
+    Primitive p = new MockPrimitive(name);
+    assertEquals(name, p.getName());
+  }
+  
+  @Test
+  public void testGetPorts_InitiallyEmpty(){
+    Primitive p = new MockPrimitive("test");
+    assertTrue(p.getPorts().isEmpty());
+  }
+  
+  @Test
+  public void testAddPort(){
+    Primitive prim = new MockPrimitive("test");
+    Port port = new Port("a", PortDirection.INPUT);
+    prim.addPort(port);
+  }
+  
+  @Test
+  public void testGetPorts_ContainsAddedPort(){
+    Primitive prim = new MockPrimitive("test");
+    Port port = new Port("a", PortDirection.INPUT);
+    prim.addPort(port);
+    assertTrue(prim.getPorts().contains(port));
+  }
+  
+  @Test
+  public void testGetPort(){
+    Primitive prim = new MockPrimitive("test");
+    Port port = new Port("a", PortDirection.INPUT);
+    prim.addPort(port);
+    assertEquals(port, prim.getPort("a"));
+  }
+
+}

--- a/src/test/java/org/manifold/backend/digital/TestPrimitive.java
+++ b/src/test/java/org/manifold/backend/digital/TestPrimitive.java
@@ -51,8 +51,9 @@ public class TestPrimitive {
     assertEquals(port, prim.getPort("a"));
   }
   
-  @Test(expected=UndeclaredIdentifierException.class)
-  public void testGetPort_nonexistent_throwsException() throws UndeclaredIdentifierException{
+  @Test(expected = UndeclaredIdentifierException.class)
+  public void testGetPort_nonexistent_throwsException() 
+      throws UndeclaredIdentifierException{
     Primitive prim = new MockPrimitive("test");
     Port bogus = prim.getPort("bogus");
   }

--- a/src/test/java/org/manifold/backend/digital/TestPrimitive.java
+++ b/src/test/java/org/manifold/backend/digital/TestPrimitive.java
@@ -44,11 +44,17 @@ public class TestPrimitive {
   }
   
   @Test
-  public void testGetPort(){
+  public void testGetPort() throws UndeclaredIdentifierException{
     Primitive prim = new MockPrimitive("test");
     Port port = new Port("a", PortDirection.INPUT);
     prim.addPort(port);
     assertEquals(port, prim.getPort("a"));
+  }
+  
+  @Test(expected=UndeclaredIdentifierException.class)
+  public void testGetPort_nonexistent_throwsException() throws UndeclaredIdentifierException{
+    Primitive prim = new MockPrimitive("test");
+    Port bogus = prim.getPort("bogus");
   }
 
 }

--- a/src/test/java/org/manifold/backend/digital/TestRegisterPrimitive.java
+++ b/src/test/java/org/manifold/backend/digital/TestRegisterPrimitive.java
@@ -12,6 +12,7 @@ import org.manifold.intermediate.BooleanValue;
 import org.manifold.intermediate.Node;
 import org.manifold.intermediate.NodeType;
 import org.manifold.intermediate.PortType;
+import org.manifold.intermediate.SchematicException;
 import org.manifold.intermediate.Type;
 
 public class TestRegisterPrimitive {
@@ -22,34 +23,34 @@ public class TestRegisterPrimitive {
   }
   
   @Test
-  public void testConstruction() throws NetlistConstructionException {
+  public void testConstruction() throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, true, true, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
   }
   
   @Test
-  public void testIsInitialValueHigh() throws NetlistConstructionException {
+  public void testIsInitialValueHigh() throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(false, true, true, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isInitialValueHigh());
   }
   
   @Test
-  public void testIsResetActiveHigh() throws NetlistConstructionException {
+  public void testIsResetActiveHigh() throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, false, true, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isResetActiveHigh());
   }
   
   @Test
-  public void testIsResetAsynchronous() throws NetlistConstructionException {
+  public void testIsResetAsynchronous() throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, true, false, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isResetAsynchronous());
   }
   
   @Test
-  public void testIsClockActiveHigh() throws NetlistConstructionException {
+  public void testIsClockActiveHigh() throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, true, true, false);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isClockActiveHigh());

--- a/src/test/java/org/manifold/backend/digital/TestRegisterPrimitive.java
+++ b/src/test/java/org/manifold/backend/digital/TestRegisterPrimitive.java
@@ -1,0 +1,58 @@
+package org.manifold.backend.digital;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.manifold.intermediate.BooleanType;
+import org.manifold.intermediate.BooleanValue;
+import org.manifold.intermediate.Node;
+import org.manifold.intermediate.NodeType;
+import org.manifold.intermediate.PortType;
+import org.manifold.intermediate.Type;
+
+public class TestRegisterPrimitive {
+  
+  @BeforeClass
+  public static void setup(){
+    TestNetlist.setupIntermediateTypes();
+  }
+  
+  @Test
+  public void testConstruction() throws NetlistConstructionException {
+    Node register = TestNetlist.instantiateRegister(true, true, true, true);
+    RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
+  }
+  
+  @Test
+  public void testIsInitialValueHigh() throws NetlistConstructionException {
+    Node register = TestNetlist.instantiateRegister(false, true, true, true);
+    RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
+    assertFalse(regPrim.isInitialValueHigh());
+  }
+  
+  @Test
+  public void testIsResetActiveHigh() throws NetlistConstructionException {
+    Node register = TestNetlist.instantiateRegister(true, false, true, true);
+    RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
+    assertFalse(regPrim.isResetActiveHigh());
+  }
+  
+  @Test
+  public void testIsResetAsynchronous() throws NetlistConstructionException {
+    Node register = TestNetlist.instantiateRegister(true, true, false, true);
+    RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
+    assertFalse(regPrim.isResetAsynchronous());
+  }
+  
+  @Test
+  public void testIsClockActiveHigh() throws NetlistConstructionException {
+    Node register = TestNetlist.instantiateRegister(true, true, true, false);
+    RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
+    assertFalse(regPrim.isClockActiveHigh());
+  }
+
+}

--- a/src/test/java/org/manifold/backend/digital/TestRegisterPrimitive.java
+++ b/src/test/java/org/manifold/backend/digital/TestRegisterPrimitive.java
@@ -23,34 +23,39 @@ public class TestRegisterPrimitive {
   }
   
   @Test
-  public void testConstruction() throws NetlistConstructionException, SchematicException {
+  public void testConstruction() 
+      throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, true, true, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
   }
   
   @Test
-  public void testIsInitialValueHigh() throws NetlistConstructionException, SchematicException {
+  public void testIsInitialValueHigh() 
+      throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(false, true, true, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isInitialValueHigh());
   }
   
   @Test
-  public void testIsResetActiveHigh() throws NetlistConstructionException, SchematicException {
+  public void testIsResetActiveHigh() 
+      throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, false, true, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isResetActiveHigh());
   }
   
   @Test
-  public void testIsResetAsynchronous() throws NetlistConstructionException, SchematicException {
+  public void testIsResetAsynchronous() 
+      throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, true, false, true);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isResetAsynchronous());
   }
   
   @Test
-  public void testIsClockActiveHigh() throws NetlistConstructionException, SchematicException {
+  public void testIsClockActiveHigh() 
+      throws NetlistConstructionException, SchematicException {
     Node register = TestNetlist.instantiateRegister(true, true, true, false);
     RegisterPrimitive regPrim = new RegisterPrimitive("reg", register);
     assertFalse(regPrim.isClockActiveHigh());

--- a/src/test/java/org/manifold/intermediate/TestSchematic.java
+++ b/src/test/java/org/manifold/intermediate/TestSchematic.java
@@ -312,6 +312,26 @@ public class TestSchematic {
   }
   
   @Test
+  public void testGetNodeName() throws SchematicException {
+    Schematic s = new Schematic("test");
+    NodeType n1Type = new NodeType(new HashMap<>(), new HashMap<>());
+    Node n1 = new Node(n1Type, new HashMap<>(), new HashMap<>());
+    String name = "n1";
+    s.addNode(name, n1);
+    
+    assertEquals(name, s.getNodeName(n1));
+  }
+  
+  @Test(expected = java.util.NoSuchElementException.class)
+  public void testGetNodeName_notInstantiated()
+      throws SchematicException {
+    Schematic s = new Schematic("test");
+    NodeType n1Type = new NodeType(new HashMap<>(), new HashMap<>());
+    Node n1 = new Node(n1Type, new HashMap<>(), new HashMap<>());
+    String name = s.getNodeName(n1);
+  }
+  
+  @Test
   public void testAddConnection() throws SchematicException {
     Schematic s = new Schematic("test");
     ConnectionType c1Type = new ConnectionType(new HashMap<>());

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+<!-- Netlist.java uses Java 8 features such as lambdas, which checkstyle 5.7 does not parse -->
+  <suppress checks=".*" files="[\\/]Netlist.java$" />
+</suppressions>


### PR DESCRIPTION
The only primitives supported right now are I/O pins and registers, for simplicity (the other gates are even easier than register, but I kept them out in order to hasten getting initial feedback). So, this touches both #117 and #118.

A number of tests are included against both valid and invalid schematics to check the behaviour of netlist-building. The valid tests are parameterized so that the same "always-true" assertions can be made for each model schematic.

I had to modify the checkstyle config to suppress checks on Netlist.java because of Java 8 parsing issues (#122). This should be reverted when a new version is available that understands Java 8 syntax.
