### PR TITLE
Pass scope into all methods that elaborate things

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -66,14 +66,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <!-- Here the default checkstyle rule restricts package name parts to
       seven characters, this is not in line with common practice at Google. -->
       <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="TypeNameCheck">
       <!-- Validates static, final fields against the
       expression "^[A-Z][a-zA-Z0-9]*$". -->
       <metadata name="altname" value="TypeName"/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="ConstantNameCheck">
@@ -86,7 +86,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="applyToPrivate" value="false"/>
       <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
       <message key="name.invalidPattern" value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="StaticVariableNameCheck">
@@ -97,8 +97,8 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="applyToProtected" value="true"/>
       <property name="applyToPackage" value="true"/>
       <property name="applyToPrivate" value="true"/>
-      <property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
-      <property name="severity" value="warning"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*_?$|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="MemberNameCheck">
@@ -109,32 +109,31 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="applyToPackage" value="true"/>
       <property name="applyToPrivate" value="true"/>
       <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="MethodNameCheck">
       <!-- Validates identifiers for method names. -->
       <metadata name="altname" value="MethodName"/>
       <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="ParameterName">
       <!-- Validates identifiers for method parameters against the
         expression "^[a-z][a-zA-Z0-9]*$". -->
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
     <module name="LocalFinalVariableName">
-      <!-- Validates identifiers for local final variables against the
-        expression "^[a-z][a-zA-Z0-9]*$". -->
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*$|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*"/>
     </module>
 
     <module name="LocalVariableName">
       <!-- Validates identifiers for local variables against the
         expression "^[a-z][a-zA-Z0-9]*$". -->
-      <property name="severity" value="warning"/>
+      <property name="severity" value="error"/>
     </module>
 
 

--- a/src/main/java/org/manifold/compiler/IntegerValue.java
+++ b/src/main/java/org/manifold/compiler/IntegerValue.java
@@ -1,7 +1,5 @@
 package org.manifold.compiler;
 
-import org.manifold.compiler.IntegerTypeValue;
-
 public class IntegerValue extends Value {
 
   private final Integer val;

--- a/src/main/java/org/manifold/compiler/IntegerValue.java
+++ b/src/main/java/org/manifold/compiler/IntegerValue.java
@@ -1,11 +1,12 @@
 package org.manifold.compiler;
 
+import org.manifold.compiler.IntegerTypeValue;
 
 public class IntegerValue extends Value {
 
   private final Integer val;
-  public IntegerValue(TypeValue t, Integer val){
-    super(t);
+  public IntegerValue(Integer val){
+    super(IntegerTypeValue.getInstance());
     this.val = val;
   }
 
@@ -18,5 +19,5 @@ public class IntegerValue extends Value {
   public boolean isRuntimeKnowable() {
     return false;
   }
-  
+
 }

--- a/src/main/java/org/manifold/compiler/front/Expression.java
+++ b/src/main/java/org/manifold/compiler/front/Expression.java
@@ -4,10 +4,10 @@ import org.manifold.compiler.TypeValue;
 import org.manifold.compiler.Value;
 
 public abstract class Expression {
-  public abstract TypeValue getType();
-  public abstract Value evaluate();
-  public abstract void verify() throws Exception;
+  public abstract TypeValue getType(Scope scope);
+  public abstract Value evaluate(Scope scope);
+  public abstract void verify(Scope scope) throws Exception;
   public abstract boolean isAssignable();
-  public abstract boolean isCompiletimeEvaluable();
-  public abstract boolean isSynthesizable();
+  public abstract boolean isCompiletimeEvaluable(Scope scope);
+  public abstract boolean isSynthesizable(Scope scope);
 }

--- a/src/main/java/org/manifold/compiler/front/LiteralExpression.java
+++ b/src/main/java/org/manifold/compiler/front/LiteralExpression.java
@@ -11,17 +11,17 @@ public class LiteralExpression extends Expression {
   }
 
   @Override
-  public TypeValue getType() {
+  public TypeValue getType(Scope scope) {
     return value.getType();
   }
 
   @Override
-  public Value evaluate() {
+  public Value evaluate(Scope scope) {
     return value;
   }
 
   @Override
-  public void verify() throws Exception{
+  public void verify(Scope scope) throws Exception{
     value.verify();
   }
 
@@ -31,12 +31,12 @@ public class LiteralExpression extends Expression {
   }
 
   @Override
-  public boolean isCompiletimeEvaluable() {
+  public boolean isCompiletimeEvaluable(Scope scope) {
     return value.isElaborationtimeKnowable();
   }
 
   @Override
-  public boolean isSynthesizable() {
+  public boolean isSynthesizable(Scope scope) {
     return value.isRuntimeKnowable();
   }
 

--- a/src/main/java/org/manifold/compiler/front/Scope.java
+++ b/src/main/java/org/manifold/compiler/front/Scope.java
@@ -49,7 +49,7 @@ public class Scope {
 
   public TypeValue getVariableType(VariableIdentifier identifier)
       throws TypeMismatchException, VariableNotDefinedException {
-    return getVariable(identifier).getType();
+    return getVariable(identifier).getType(this);
   }
 
   public Variable getVariable(VariableIdentifier identifier)
@@ -70,7 +70,7 @@ public class Scope {
 
   public Value getVariableValue(VariableIdentifier identifier)
       throws VariableNotAssignedException, VariableNotDefinedException {
-    return getVariable(identifier).getValue();
+    return getVariable(identifier).getValue(this);
   }
 
   public void assignVariable(VariableIdentifier identifier,

--- a/src/main/java/org/manifold/compiler/front/Scope.java
+++ b/src/main/java/org/manifold/compiler/front/Scope.java
@@ -33,7 +33,7 @@ public class Scope {
     }
     // naturally, variable shadowing is allowed -- "closer" scopes hide
     // "further" ones
-    Variable v = new Variable(identifier, typeExpression);
+    Variable v = new Variable(this, identifier, typeExpression);
     symbolTable.put(identifier, v);
   }
 
@@ -49,7 +49,7 @@ public class Scope {
 
   public TypeValue getVariableType(VariableIdentifier identifier)
       throws TypeMismatchException, VariableNotDefinedException {
-    return getVariable(identifier).getType(this);
+    return getVariable(identifier).getType();
   }
 
   public Variable getVariable(VariableIdentifier identifier)
@@ -70,7 +70,7 @@ public class Scope {
 
   public Value getVariableValue(VariableIdentifier identifier)
       throws VariableNotAssignedException, VariableNotDefinedException {
-    return getVariable(identifier).getValue(this);
+    return getVariable(identifier).getValue();
   }
 
   public void assignVariable(VariableIdentifier identifier,

--- a/src/main/java/org/manifold/compiler/front/Variable.java
+++ b/src/main/java/org/manifold/compiler/front/Variable.java
@@ -20,19 +20,19 @@ public class Variable {
     return identifier;
   }
 
-  public TypeValue getType() {
-    return (TypeValue) typeExpression.evaluate();
+  public TypeValue getType(Scope scope) {
+    return (TypeValue) typeExpression.evaluate(scope);
   }
 
   public boolean isAssigned() {
     return assigned;
   }
 
-  public Value getValue() {
+  public Value getValue(Scope scope) {
     if (!isAssigned()) {
       return null;
     } else {
-      return valueExpression.evaluate();
+      return valueExpression.evaluate(scope);
     }
   }
 
@@ -46,23 +46,23 @@ public class Variable {
     this.assigned = true;
   }
   
-  public void verify() throws TypeMismatchException {
+  public void verify(Scope scope) throws TypeMismatchException {
     // Ensure the Type is an actual type
-    if (typeExpression.getType() != TypeTypeValue.getInstance()) {
+    if (typeExpression.getType(scope) != TypeTypeValue.getInstance()) {
       // TODO(lucas) We should have a special exception for the case where
       // a nontype value is used as a type.
       throw new TypeMismatchException(
           TypeTypeValue.getInstance(),
-          typeExpression.getType()
+          typeExpression.getType(scope)
       );
     }
     
     // Ensure the value is of the correct type
     // TODO(lucas)
-    if (assigned && !(valueExpression.getType().isSubtypeOf(getType()))) {
+    if (assigned && !(valueExpression.getType(scope).isSubtypeOf(getType(scope)))) {
       throw new TypeMismatchException(
-          getType(),
-          valueExpression.getType()
+          getType(scope),
+          valueExpression.getType(scope)
       );
     }
   }

--- a/src/main/java/org/manifold/compiler/front/Variable.java
+++ b/src/main/java/org/manifold/compiler/front/Variable.java
@@ -7,11 +7,16 @@ import org.manifold.compiler.TypeTypeValue;
 public class Variable {
   private final VariableIdentifier identifier;
   private final Expression typeExpression;
+  private final Scope scope;
 
   private boolean assigned = false;
   private Expression valueExpression;
 
-  public Variable(VariableIdentifier identifier, Expression typeExpression) {
+  public Variable(
+      Scope scope,
+      VariableIdentifier identifier,
+      Expression typeExpression) {
+    this.scope = scope;
     this.identifier = identifier;
     this.typeExpression = typeExpression;
   }
@@ -20,15 +25,19 @@ public class Variable {
     return identifier;
   }
 
-  public TypeValue getType(Scope scope) {
+  public TypeValue getType() {
     return (TypeValue) typeExpression.evaluate(scope);
+  }
+  
+  public Scope getScope() {
+    return scope;
   }
 
   public boolean isAssigned() {
     return assigned;
   }
 
-  public Value getValue(Scope scope) {
+  public Value getValue() {
     if (!isAssigned()) {
       return null;
     } else {
@@ -46,7 +55,7 @@ public class Variable {
     this.assigned = true;
   }
   
-  public void verify(Scope scope) throws TypeMismatchException {
+  public void verify() throws TypeMismatchException {
     // Ensure the Type is an actual type
     if (typeExpression.getType(scope) != TypeTypeValue.getInstance()) {
       // TODO(lucas) We should have a special exception for the case where
@@ -59,9 +68,9 @@ public class Variable {
     
     // Ensure the value is of the correct type
     // TODO(lucas)
-    if (assigned && !(valueExpression.getType(scope).isSubtypeOf(getType(scope)))) {
+    if (assigned && !(valueExpression.getType(scope).isSubtypeOf(getType()))) {
       throw new TypeMismatchException(
-          getType(scope),
+          getType(),
           valueExpression.getType(scope)
       );
     }

--- a/src/main/java/org/manifold/compiler/front/VariableAssignmentExpression.java
+++ b/src/main/java/org/manifold/compiler/front/VariableAssignmentExpression.java
@@ -17,7 +17,7 @@ public class VariableAssignmentExpression extends Expression {
   @Override
   public TypeValue getType(Scope scope) {
     try {
-      return scope.getVariable(variable).getType(scope);
+      return scope.getVariable(variable).getType();
     } catch (VariableNotDefinedException ex) {
       assert(false);
       return null;
@@ -27,7 +27,7 @@ public class VariableAssignmentExpression extends Expression {
   @Override
   public Value evaluate(Scope scope) {
     try {
-      return scope.getVariable(variable).getValue(scope);
+      return scope.getVariable(variable).getValue();
     } catch (VariableNotDefinedException ex) {
       assert(false);
       return null;

--- a/src/main/java/org/manifold/compiler/front/VariableAssignmentExpression.java
+++ b/src/main/java/org/manifold/compiler/front/VariableAssignmentExpression.java
@@ -4,31 +4,39 @@ import org.manifold.compiler.TypeValue;
 import org.manifold.compiler.Value;
 
 public class VariableAssignmentExpression extends Expression {
-  private Variable variable;
+  private VariableIdentifier variable;
   private Expression valueExpression;
 
   public VariableAssignmentExpression(
-      Variable variable,
+      VariableIdentifier variable,
       Expression valueExpression) throws Exception {
     this.variable = variable;
     this.valueExpression = valueExpression;
-    this.variable.setValueExpression(valueExpression);
   }
 
   @Override
-  public TypeValue getType() {
-    return variable.getType();
+  public TypeValue getType(Scope scope) {
+    try {
+      return scope.getVariable(variable).getType(scope);
+    } catch (VariableNotDefinedException ex) {
+      assert(false);
+      return null;
+    }
   }
 
   @Override
-  public Value evaluate() {
-    return variable.getValue();
+  public Value evaluate(Scope scope) {
+    try {
+      return scope.getVariable(variable).getValue(scope);
+    } catch (VariableNotDefinedException ex) {
+      assert(false);
+      return null;
+    }
   }
 
   @Override
-  public void verify() throws Exception{
-    variable.verify();
-    valueExpression.verify();
+  public void verify(Scope scope) throws Exception{
+    valueExpression.verify(scope);
   }
 
   @Override
@@ -37,13 +45,13 @@ public class VariableAssignmentExpression extends Expression {
   }
 
   @Override
-  public boolean isCompiletimeEvaluable() {
-    return valueExpression.evaluate().isElaborationtimeKnowable();
+  public boolean isCompiletimeEvaluable(Scope scope) {
+    return valueExpression.evaluate(scope).isElaborationtimeKnowable();
   }
 
   @Override
-  public boolean isSynthesizable() {
-    return valueExpression.evaluate().isRuntimeKnowable();
+  public boolean isSynthesizable(Scope scope) {
+    return valueExpression.evaluate(scope).isRuntimeKnowable();
   }
 
 }

--- a/src/main/java/org/manifold/compiler/front/VariableIdentifier.java
+++ b/src/main/java/org/manifold/compiler/front/VariableIdentifier.java
@@ -1,10 +1,20 @@
 package org.manifold.compiler.front;
 
+import java.util.List;
+
 public class VariableIdentifier {
 
   private String name;
   private NamespaceIdentifier namespaceIdentifier;
 
+  public VariableIdentifier(List<String> identifiers) {
+    assert(identifiers.size() > 0);
+    this.name = identifiers.get(identifiers.size() - 1);
+    this.namespaceIdentifier = new NamespaceIdentifier(
+        identifiers.subList(0, identifiers.size() - 1)
+    );
+  }
+  
   public VariableIdentifier(NamespaceIdentifier namespaceIdentifier,
       String name) {
     this.name = name;

--- a/src/main/java/org/manifold/compiler/front/VariableReferenceExpression.java
+++ b/src/main/java/org/manifold/compiler/front/VariableReferenceExpression.java
@@ -40,7 +40,7 @@ public class VariableReferenceExpression extends Expression {
   @Override
   public boolean isCompiletimeEvaluable(Scope scope) {
     try {
-      return scope.getVariable(variable).getValue(scope).isElaborationtimeKnowable();
+      return scope.getVariable(variable).getValue().isElaborationtimeKnowable();
     } catch (VariableNotDefinedException ex) {
       assert(false);
       return false;
@@ -50,7 +50,7 @@ public class VariableReferenceExpression extends Expression {
   @Override
   public boolean isSynthesizable(Scope scope) {
     try {
-      return scope.getVariable(variable).getValue(scope).isRuntimeKnowable();
+      return scope.getVariable(variable).getValue().isRuntimeKnowable();
     } catch (VariableNotDefinedException ex) {
       assert(false);
       return false;

--- a/src/main/java/org/manifold/compiler/front/VariableReferenceExpression.java
+++ b/src/main/java/org/manifold/compiler/front/VariableReferenceExpression.java
@@ -1,31 +1,35 @@
 package org.manifold.compiler.front;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.manifold.compiler.TypeValue;
 import org.manifold.compiler.Value;
 
 public class VariableReferenceExpression extends Expression {
-  private final Variable variable;
+  private final VariableIdentifier variable;
 
-  public VariableReferenceExpression(Variable variable) {
+  public VariableReferenceExpression(VariableIdentifier variable) {
     this.variable = variable;
   }
 
   @Override
-  public TypeValue getType() {
-    return variable.getType();
+  public TypeValue getType(Scope scope) {
+    return null;
+    //return variable.getType();
   }
 
   @Override
-  public Value evaluate() {
-    return variable.getValue();
+  public Value evaluate(Scope scope) {
+    return null;
+    //return variable.getValue();
   }
 
   @Override
-  public void verify() throws Exception {
-    variable.verify();
-    if (!variable.isAssigned()) {
-      throw new VariableNotAssignedException(variable);
-    }
+  public void verify(Scope scope) throws Exception {
+    // variable.verify();
+    // if (!variable.isAssigned()) {
+    //   throw new VariableNotAssignedException(variable);
+    // }
   }
 
   @Override
@@ -34,13 +38,23 @@ public class VariableReferenceExpression extends Expression {
   }
 
   @Override
-  public boolean isCompiletimeEvaluable() {
-    return variable.getValue().isElaborationtimeKnowable();
+  public boolean isCompiletimeEvaluable(Scope scope) {
+    try {
+      return scope.getVariable(variable).getValue(scope).isElaborationtimeKnowable();
+    } catch (VariableNotDefinedException ex) {
+      assert(false);
+      return false;
+    }
   }
 
   @Override
-  public boolean isSynthesizable() {
-    return variable.getValue().isRuntimeKnowable();
+  public boolean isSynthesizable(Scope scope) {
+    try {
+      return scope.getVariable(variable).getValue(scope).isRuntimeKnowable();
+    } catch (VariableNotDefinedException ex) {
+      assert(false);
+      return false;
+    }
   }
 
 }

--- a/src/main/java/org/manifold/compiler/middle/serialization/SchematicDeserializer.java
+++ b/src/main/java/org/manifold/compiler/middle/serialization/SchematicDeserializer.java
@@ -92,11 +92,11 @@ public class SchematicDeserializer {
     TypeValue bool = sch.getUserDefinedType("Bool");
     TypeValue integer = sch.getUserDefinedType("Int");
     TypeValue str = sch.getUserDefinedType("String");
-    
+
     for (Entry<String, JsonElement> attrEntry : attributeMapJson.entrySet()) {
       TypeValue type = expectedTypes.get(attrEntry.getKey());
       Value attrValue = null;
-      
+
       String valueString = attrEntry.getValue().getAsString();
 
       if (type == null) {
@@ -111,14 +111,13 @@ public class SchematicDeserializer {
         }
         attrValue = BooleanValue.getInstance(Boolean.parseBoolean(valueString));
       } else if (type.equals(integer)) {
-        attrValue = new IntegerValue(IntegerTypeValue.getInstance(),
-              Integer.valueOf(valueString));
+        attrValue = new IntegerValue(Integer.valueOf(valueString));
       } else if (type.equals(str)) {
         attrValue = new StringValue(StringTypeValue.getInstance(), valueString);
       } else {
         throw new UndeclaredAttributeException(attrEntry.getKey());
       }
-      
+
       attributeMap.put(attrEntry.getKey(), attrValue);
     }
 
@@ -193,7 +192,7 @@ public class SchematicDeserializer {
 
   /**
    * Node defn:
-   * 
+   *
    * <pre>
    * nodes: {
    *  node_one: {

--- a/src/test/java/org/manifold/compiler/back/TestNetlist.java
+++ b/src/test/java/org/manifold/compiler/back/TestNetlist.java
@@ -28,11 +28,11 @@ public class TestNetlist {
     Schematic sch = UtilSchematicConstruction.instantiateSchematic("case0");
     NodeValue in = UtilSchematicConstruction.instantiateInputPin();
     NodeValue out = UtilSchematicConstruction.instantiateOutputPin();
-    ConnectionValue in_to_out = UtilSchematicConstruction.instantiateWire(
+    ConnectionValue inToOut = UtilSchematicConstruction.instantiateWire(
         in.getPort("out"), out.getPort("in"));
     sch.addNode("in", in);
     sch.addNode("out", out);
-    sch.addConnection("in_to_out", in_to_out);
+    sch.addConnection("in_to_out", inToOut);
 
     Netlist netlist = new Netlist(sch);
   }
@@ -43,11 +43,11 @@ public class TestNetlist {
     Schematic sch = UtilSchematicConstruction.instantiateSchematic("case0");
     NodeValue in = UtilSchematicConstruction.instantiateInputPin();
     NodeValue out = UtilSchematicConstruction.instantiateOutputPin();
-    ConnectionValue in_to_out = UtilSchematicConstruction.instantiateWire(
+    ConnectionValue inToOut = UtilSchematicConstruction.instantiateWire(
         in.getPort("out"), out.getPort("in"));
     sch.addNode("in", in);
     sch.addNode("out", out);
-    sch.addConnection("in_to_out", in_to_out);
+    sch.addConnection("in_to_out", inToOut);
 
     Netlist netlist = new Netlist(sch);
 
@@ -55,9 +55,9 @@ public class TestNetlist {
     // there should be exactly one net
     assertEquals(1, nets.values().size());
     // and this net should contain both ports
-    Net n_in_to_out = (Net) nets.values().toArray()[0];
-    assertTrue(n_in_to_out.getConnectedPorts().contains(in.getPort("out")));
-    assertTrue(n_in_to_out.getConnectedPorts().contains(out.getPort("in")));
+    Net nInToOut = (Net) nets.values().toArray()[0];
+    assertTrue(nInToOut.getConnectedPorts().contains(in.getPort("out")));
+    assertTrue(nInToOut.getConnectedPorts().contains(out.getPort("in")));
   }
 
   @Test
@@ -66,20 +66,20 @@ public class TestNetlist {
     Schematic sch = UtilSchematicConstruction.instantiateSchematic("case0");
     NodeValue in = UtilSchematicConstruction.instantiateInputPin();
     NodeValue out = UtilSchematicConstruction.instantiateOutputPin();
-    ConnectionValue in_to_out = UtilSchematicConstruction.instantiateWire(
+    ConnectionValue inToOut = UtilSchematicConstruction.instantiateWire(
         in.getPort("out"), out.getPort("in"));
     sch.addNode("in", in);
     sch.addNode("out", out);
-    sch.addConnection("in_to_out", in_to_out);
+    sch.addConnection("in_to_out", inToOut);
 
     Netlist netlist = new Netlist(sch);
 
     // `in` and `out` should both be connected to the same net
-    Net n_in = netlist.getConnectedNet(in.getPort("out"));
-    assertNotNull(n_in);
-    Net n_out = netlist.getConnectedNet(out.getPort("in"));
-    assertNotNull(n_out);
-    assertEquals(n_in, n_out);
+    Net nIn = netlist.getConnectedNet(in.getPort("out"));
+    assertNotNull(nIn);
+    Net nOut = netlist.getConnectedNet(out.getPort("in"));
+    assertNotNull(nOut);
+    assertEquals(nIn, nOut);
   }
 
 }

--- a/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java
+++ b/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java
@@ -40,16 +40,16 @@ public class TestNoMultipleDriversCheck {
       case0.addNode("in0", in0);
       NodeValue out0 = UtilSchematicConstruction.instantiateOutputPin();
       case0.addNode("out0", out0);
-      ConnectionValue in0_to_out0 = UtilSchematicConstruction.instantiateWire(
+      ConnectionValue in0ToOut0 = UtilSchematicConstruction.instantiateWire(
           in0.getPort("out"), out0.getPort("in"));
-      case0.addConnection("in0_to_out0", in0_to_out0);
+      case0.addConnection("in0_to_out0", in0ToOut0);
 
-      Netlist netlist_case0 = new Netlist(case0);
-      Object[] case0_data = new Object[] { case0, netlist_case0, true };
-      testData.add(case0_data);
+      Netlist netlistCase0 = new Netlist(case0);
+      Object[] case0Data = new Object[] { case0, netlistCase0, true };
+      testData.add(case0Data);
     }
     // END CASE 0
-    
+
     // BEGIN CASE 1
     // |in0> -+- <out0|
     // |in1> -|
@@ -62,16 +62,16 @@ public class TestNoMultipleDriversCheck {
       case1.addNode("in1", in1);
       NodeValue out0 = UtilSchematicConstruction.instantiateOutputPin();
       case1.addNode("out0", out0);
-      ConnectionValue in0_to_out0 = UtilSchematicConstruction.instantiateWire(
+      ConnectionValue in0ToOut0 = UtilSchematicConstruction.instantiateWire(
           in0.getPort("out"), out0.getPort("in"));
-      case1.addConnection("in0_to_out0", in0_to_out0);
-      ConnectionValue in1_to_out0 = UtilSchematicConstruction.instantiateWire(
+      case1.addConnection("in0_to_out0", in0ToOut0);
+      ConnectionValue in1ToOut0 = UtilSchematicConstruction.instantiateWire(
           in1.getPort("out"), out0.getPort("in"));
-      case1.addConnection("in1_to_out0", in1_to_out0);
+      case1.addConnection("in1_to_out0", in1ToOut0);
 
-      Netlist netlist_case1 = new Netlist(case1);
-      Object[] case1_data = new Object[] { case1, netlist_case1, false };
-      testData.add(case1_data);
+      Netlist netlistCase1 = new Netlist(case1);
+      Object[] case1Data = new Object[] { case1, netlistCase1, false };
+      testData.add(case1Data);
     }
     // END CASE 1
     return testData;
@@ -82,7 +82,7 @@ public class TestNoMultipleDriversCheck {
   private Netlist netlist;
   private boolean expectedCheckResult;
 
-  public TestNoMultipleDriversCheck(Schematic schematic, Netlist netlist, 
+  public TestNoMultipleDriversCheck(Schematic schematic, Netlist netlist,
       Boolean expectedCheckResult) {
     this.schematic = schematic;
     this.netlist = netlist;

--- a/src/test/java/org/manifold/compiler/back/TestVHDLCodeGenerator.java
+++ b/src/test/java/org/manifold/compiler/back/TestVHDLCodeGenerator.java
@@ -57,9 +57,9 @@ public class TestVHDLCodeGenerator {
     schematic.addNode("in0", in0);
     NodeValue out0 = UtilSchematicConstruction.instantiateOutputPin();
     schematic.addNode("out0", out0);
-    ConnectionValue in0_to_out0 = UtilSchematicConstruction.instantiateWire(
+    ConnectionValue in0ToOut0 = UtilSchematicConstruction.instantiateWire(
         in0.getPort("out"), out0.getPort("in"));
-    schematic.addConnection("in0_to_out0", in0_to_out0);
+    schematic.addConnection("in0_to_out0", in0ToOut0);
     
     VHDLCodeGenerator codegen = new VHDLCodeGenerator(schematic);
     File tempdir = folder.getRoot();

--- a/src/test/java/org/manifold/compiler/front/TestMultipleAssignmentException.java
+++ b/src/test/java/org/manifold/compiler/front/TestMultipleAssignmentException.java
@@ -24,7 +24,11 @@ public class TestMultipleAssignmentException {
   }
   
   public Variable getVariableInstance() {
-    return new Variable(getVariableIdentifierInstance(), getTypeExpression());
+    return new Variable(
+        new Scope(),
+        getVariableIdentifierInstance(),
+        getTypeExpression()
+    );
   }
   
   public MultipleAssignmentException getInstance() {

--- a/src/test/java/org/manifold/compiler/front/TestScope.java
+++ b/src/test/java/org/manifold/compiler/front/TestScope.java
@@ -74,7 +74,7 @@ public class TestScope {
 
     Scope s = new Scope();
     s.defineVariable(getVariableIdentifier(), getTypeExpression());
-    assertEquals(getTypeExpression().evaluate(),
+    assertEquals(getTypeExpression().evaluate(s),
         s.getVariableType(getVariableIdentifier()));
   }
 
@@ -92,7 +92,7 @@ public class TestScope {
     Variable v = s.getVariable(getVariableIdentifier());
 
     assertEquals(v.getIdentifier(), getVariableIdentifier());
-    assertEquals(v.getType(), getTypeExpression().evaluate());
+    assertEquals(v.getType(), getTypeExpression().evaluate(s));
   }
 
   @Test
@@ -116,7 +116,7 @@ public class TestScope {
     s.defineVariable(getVariableIdentifier(), getTypeExpression());
     s.assignVariable(getVariableIdentifier(), getValueExpression());
 
-    assertEquals(getValueExpression().evaluate(),
+    assertEquals(getValueExpression().evaluate(s),
         s.getVariableValue(getVariableIdentifier()));
   }
 
@@ -135,7 +135,7 @@ public class TestScope {
     s.defineVariable(getVariableIdentifier(), getTypeExpression());
     s.assignVariable(getVariableIdentifier(), getValueExpression());
     assertEquals(s.getVariableValue(getVariableIdentifier()),
-        getValueExpression().evaluate());
+        getValueExpression().evaluate(s));
   }
 
   @Test(expected = MultipleAssignmentException.class)

--- a/src/test/java/org/manifold/compiler/front/TestVariable.java
+++ b/src/test/java/org/manifold/compiler/front/TestVariable.java
@@ -1,10 +1,12 @@
 package org.manifold.compiler.front;
 
-import org.manifold.compiler.BooleanValue;
-import org.manifold.compiler.BooleanTypeValue;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.manifold.compiler.BooleanTypeValue;
+import org.manifold.compiler.BooleanValue;
+import org.manifold.compiler.TypeValue;
+import org.manifold.compiler.Value;
 
 public class TestVariable {
   private NamespaceIdentifier getNamespaceIdentifier() {
@@ -14,18 +16,34 @@ public class TestVariable {
   private VariableIdentifier getVariableIdentifier() {
     return new VariableIdentifier(getNamespaceIdentifier(), "foo");
   }
-
+  
+  private Scope getScope() {
+    return new Scope();
+  }
+  
   private Variable getVariable() {
     // declare "foo" as a variable that stores a Type
-    return new Variable(getVariableIdentifier(), getTypeExpression());
+    return new Variable(
+        getScope(),
+        getVariableIdentifier(),
+        getTypeExpression()
+    );
+  }
+  
+  private TypeValue getTypeValue() {
+    return BooleanTypeValue.getInstance();
+  }
+  
+  private Value getValue() {
+    return BooleanValue.getInstance(true);
   }
 
   private Expression getTypeExpression(){
-    return new LiteralExpression(BooleanTypeValue.getInstance());
+    return new LiteralExpression(getTypeValue());
   }
 
   private Expression getValueExpression(){
-    return new LiteralExpression(BooleanValue.getInstance(true));
+    return new LiteralExpression(getValue());
   }
 
   @Test
@@ -35,7 +53,10 @@ public class TestVariable {
 
   @Test
   public void testGetTypeValue() throws TypeMismatchException {
-    assertEquals(getVariable().getType(), getTypeExpression().evaluate());
+    assertEquals(
+        getVariable().getType(),
+        getTypeExpression().evaluate(getVariable().getScope())
+    );
   }
 
   public void testGetValueUnassigned() throws VariableNotAssignedException {
@@ -50,7 +71,7 @@ public class TestVariable {
       VariableNotAssignedException {
     Variable v = getVariable();
     v.setValueExpression(getValueExpression());
-    assertEquals(getValueExpression().evaluate(), v.getValue());
+    assertEquals(v.getValue(), getValue());
   }
 
   @Test(expected = MultipleAssignmentException.class)
@@ -66,6 +87,7 @@ public class TestVariable {
       MultipleAssignmentException {
 
     Variable v = new Variable(
+        getScope(),
         getVariableIdentifier(),
         new LiteralExpression(BooleanValue.getInstance(false))
     );
@@ -78,6 +100,7 @@ public class TestVariable {
       MultipleAssignmentException {
 
     Variable v = new Variable(
+        getScope(),
         getVariableIdentifier(),
         new LiteralExpression(BooleanTypeValue.getInstance())
     );

--- a/src/test/java/org/manifold/compiler/front/TestVariableNotAssignedException.java
+++ b/src/test/java/org/manifold/compiler/front/TestVariableNotAssignedException.java
@@ -23,7 +23,11 @@ public class TestVariableNotAssignedException {
   }
   
   public Variable getVariableInstance(){
-    return new Variable(getVariableIdentifierInstance(), getTypeExpression());
+    return new Variable(
+        new Scope(),
+        getVariableIdentifierInstance(),
+        getTypeExpression()
+    );
   }
   
   public VariableNotAssignedException getInstance(){


### PR DESCRIPTION
## Fixes Compiler Warnings

This isn't coooool

```
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNetlist.java:31:21: warning: Name 'in_to_out' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNetlist.java:46:21: warning: Name 'in_to_out' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNetlist.java:58:9: warning: Name 'n_in_to_out' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNetlist.java:69:21: warning: Name 'in_to_out' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNetlist.java:78:9: warning: Name 'n_in' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNetlist.java:80:9: warning: Name 'n_out' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:43:23: warning: Name 'in0_to_out0' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:47:15: warning: Name 'netlist_case0' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:48:16: warning: Name 'case0_data' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:65:23: warning: Name 'in0_to_out0' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:68:23: warning: Name 'in1_to_out0' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:72:15: warning: Name 'netlist_case1' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestNoMultipleDriversCheck.java:73:16: warning: Name 'case1_data' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/back/TestVHDLCodeGenerator.java:60:21: warning: Name 'in0_to_out0' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/serialization/TestSerialization.java:116:18: warning: Name 'IN_NODE_NAME' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/serialization/TestSerialization.java:117:18: warning: Name 'OUT_NODE_NAME' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/serialization/TestSerialization.java:118:18: warning: Name 'DIGITAL_IN_PORT_NAME' must match pattern '^[a-z][a-zA-Z0-9]*$'.
[ant:checkstyle] /Users/lucaswoj/Projects/Manifold/Repository/src/test/java/org/manifold/compiler/serialization/TestSerialization.java:119:18: warning: Name 'DIGITAL_OUT_PORT_NAME' must match pattern '^[a-z][a-zA-Z0-9]*$'.
```
## Passes Scope Objects to all Elaboration Operations
