### PR TITLE
Enable type checking for attributes #80

### DIFF
--- a/src/main/java/org/manifold/compiler/ConnectionValue.java
+++ b/src/main/java/org/manifold/compiler/ConnectionValue.java
@@ -25,7 +25,8 @@ public class ConnectionValue extends Value {
 
   public ConnectionValue(ConnectionType type, PortValue from, PortValue to,
       Map<String, Value> attrs)
-      throws UndeclaredAttributeException, InvalidAttributeException {
+      throws UndeclaredAttributeException, InvalidAttributeException,
+      TypeMismatchException {
     super(type);
     this.attributes = new Attributes(type.getAttributes(), attrs);
     this.portFrom = checkNotNull(from);

--- a/src/main/java/org/manifold/compiler/ConstraintValue.java
+++ b/src/main/java/org/manifold/compiler/ConstraintValue.java
@@ -12,7 +12,8 @@ public class ConstraintValue extends Value {
   }
 
   public ConstraintValue(ConstraintType type, Map<String, Value> attrs)
-      throws UndeclaredAttributeException, InvalidAttributeException {
+      throws UndeclaredAttributeException, InvalidAttributeException,
+      TypeMismatchException {
     super(type);
     this.attributes = new Attributes(type.getAttributes(), attrs);
   }

--- a/src/main/java/org/manifold/compiler/PortValue.java
+++ b/src/main/java/org/manifold/compiler/PortValue.java
@@ -20,7 +20,7 @@ public class PortValue extends Value {
 
   public PortValue(PortTypeValue type, NodeValue parent,
       Map<String, Value> attrMap) throws UndeclaredAttributeException,
-      InvalidAttributeException {
+      InvalidAttributeException, TypeMismatchException {
 
     super(type);
     this.attributes = new Attributes(type.getAttributes(), attrMap);

--- a/src/main/java/org/manifold/compiler/middle/serialization/SchematicDeserializer.java
+++ b/src/main/java/org/manifold/compiler/middle/serialization/SchematicDeserializer.java
@@ -1,5 +1,6 @@
 package org.manifold.compiler.middle.serialization;
 
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -8,7 +9,6 @@ import org.manifold.compiler.BooleanValue;
 import org.manifold.compiler.ConnectionType;
 import org.manifold.compiler.ConnectionValue;
 import org.manifold.compiler.ConstraintType;
-import org.manifold.compiler.IntegerTypeValue;
 import org.manifold.compiler.IntegerValue;
 import org.manifold.compiler.InvalidAttributeException;
 import org.manifold.compiler.MultipleAssignmentException;
@@ -19,6 +19,7 @@ import org.manifold.compiler.PortTypeValue;
 import org.manifold.compiler.PortValue;
 import org.manifold.compiler.StringTypeValue;
 import org.manifold.compiler.StringValue;
+import org.manifold.compiler.TypeMismatchException;
 import org.manifold.compiler.TypeValue;
 import org.manifold.compiler.UndeclaredAttributeException;
 import org.manifold.compiler.UndeclaredIdentifierException;
@@ -246,7 +247,8 @@ public class SchematicDeserializer {
    */
   private void deserializeConnections(Schematic sch, JsonObject in)
       throws UndeclaredIdentifierException, UndeclaredAttributeException,
-      InvalidAttributeException, MultipleAssignmentException {
+      InvalidAttributeException, MultipleAssignmentException,
+      TypeMismatchException {
 
     for (Entry<String, JsonElement> entry : in.entrySet()) {
       JsonObject obj = entry.getValue().getAsJsonObject();

--- a/src/test/java/org/manifold/compiler/TestNode.java
+++ b/src/test/java/org/manifold/compiler/TestNode.java
@@ -6,10 +6,10 @@ import com.google.common.collect.ImmutableMap;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.manifold.compiler.middle.SchematicException;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.manifold.compiler.middle.SchematicException;
 
 public class TestNode {
 
@@ -42,6 +42,7 @@ public class TestNode {
     new NodeValue(hasABCNodeAttr, ImmutableMap.of("abc", v), new HashMap<>());
   }
   
+
   @Test(
       expected = org.manifold.compiler.UndeclaredIdentifierException.class)
   public void testCreateWithInvalidPortName() throws SchematicException {
@@ -61,6 +62,12 @@ public class TestNode {
         PORT_ATTRS
     );
     assertEquals(v, n.getAttribute("abc"));
+  }
+
+  @Test(expected = org.manifold.compiler.TypeMismatchException.class)
+  public void testCreateWithInvalidPortType() throws SchematicException {
+    Value vInt = new IntegerValue(42);
+    new NodeValue(hasABCNodeAttr, ImmutableMap.of("abc", vInt), PORT_ATTRS);
   }
 
   @Test(expected = org.manifold.compiler.UndeclaredAttributeException.class)

--- a/src/test/java/org/manifold/compiler/back/UtilSchematicConstruction.java
+++ b/src/test/java/org/manifold/compiler/back/UtilSchematicConstruction.java
@@ -13,6 +13,7 @@ import org.manifold.compiler.NodeTypeValue;
 import org.manifold.compiler.NodeValue;
 import org.manifold.compiler.PortTypeValue;
 import org.manifold.compiler.PortValue;
+import org.manifold.compiler.TypeMismatchException;
 import org.manifold.compiler.TypeValue;
 import org.manifold.compiler.UndeclaredAttributeException;
 import org.manifold.compiler.Value;
@@ -152,7 +153,8 @@ public class UtilSchematicConstruction {
   }
 
   public static ConnectionValue instantiateWire(PortValue from, PortValue to)
-      throws UndeclaredAttributeException, InvalidAttributeException {
+      throws UndeclaredAttributeException, InvalidAttributeException,
+      TypeMismatchException {
     ConnectionValue wire = new ConnectionValue(digitalWireType, from, to,
         noAttributes);
     return wire;


### PR DESCRIPTION
@mtrberzi

Should this check if attributes are a subtype or equal?

Also, it seems like some types, such as NodeTypeValue, wouldn't make sense as
an Attribute.
Should the values in an Attribute be restricted to satisfy
isRuntimeKnowable() or isElaborationTimeKnowable()?
